### PR TITLE
PrezelChip 구현

### DIFF
--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChip.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChip.kt
@@ -1,12 +1,13 @@
 package com.team.prezel.core.designsystem.component.chip
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Surface
@@ -34,24 +35,24 @@ fun PrezelChip(
     val hasIcon = icon != null
     val iconOnly = hasIcon && !hasText
     require(hasText || hasIcon) { "Chip은 text 또는 icon 중 하나는 반드시 필요합니다." }
-    val (chipType, chipSize, interaction, feedback) = style
+    val (_, chipSize, _, _) = style
 
     Surface(
         modifier = modifier,
-        shape = prezelChipShape(chipSize),
-        color = prezelChipContainerColor(type = chipType, interaction = interaction, feedback = feedback, iconOnly = iconOnly),
-        border = prezelChipBorderStroke(type = chipType, interaction = interaction, feedback = feedback),
+        shape = style.shape(),
+        color = style.containerColor(iconOnly = iconOnly),
+        border = style.borderStroke(),
     ) {
         CompositionLocalProvider(
-            LocalTextStyle provides prezelChipTextStyle(chipSize),
-            LocalContentColor provides prezelChipContentColor(interaction = interaction, feedback = feedback),
+            LocalTextStyle provides style.textStyle(),
+            LocalContentColor provides style.contentColor(),
         ) {
             Row(
-                modifier = Modifier.padding(prezelChipContentPadding(size = chipSize, onlyIcon = hasIcon && !hasText)),
+                modifier = Modifier.padding(style.contentPadding(iconOnly = iconOnly)),
                 horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                PrezelChipIcon(icon = icon, size = chipSize)
+                PrezelChipIcon(icon = icon, style = style)
 
                 if (!hasText) return@Row
                 if (hasIcon) {
@@ -78,93 +79,64 @@ fun PrezelChip(
     val hasIcon = icon != null
     val iconOnly = hasIcon && !hasText
     require(hasText || hasIcon) { "Chip은 text 또는 icon 중 하나는 반드시 필요합니다." }
-    val (_, chipSize, _, _) = style
 
-    val resolvedBorder =
-        resolveChipBorder(
-            style = style,
-            hasCustomContainerColor = containerColor != null,
-        )
+    val colors = PrezelChipColors(
+        containerColor = containerColor,
+        contentColor = contentColor,
+    )
 
-    val resolvedContainerColor =
-        resolveChipContainerColor(
-            style = style,
-            iconOnly = iconOnly,
-            overrideColor = containerColor,
-        )
+    CompositionLocalProvider(LocalPrezelChipColors provides colors) {
+        val resolvedContainer = style.containerColor(iconOnly = iconOnly)
+        val resolvedContent = style.contentColor()
+        val resolvedBorder = style.borderStroke()
 
-    val resolvedContentColor =
-        resolveChipContentColor(
-            style = style,
-            overrideColor = contentColor,
-        )
-
-    Surface(
-        modifier = modifier,
-        shape = prezelChipShape(chipSize),
-        color = resolvedContainerColor,
-        border = resolvedBorder,
-    ) {
-        CompositionLocalProvider(
-            LocalTextStyle provides prezelChipTextStyle(chipSize),
-            LocalContentColor provides resolvedContentColor,
+        Surface(
+            modifier = modifier,
+            shape = style.shape(),
+            color = resolvedContainer,
+            border = resolvedBorder,
         ) {
-            Row(
-                modifier = Modifier.padding(prezelChipContentPadding(size = chipSize, onlyIcon = hasIcon && !hasText)),
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically,
+            CompositionLocalProvider(
+                LocalTextStyle provides style.textStyle(),
+                LocalContentColor provides resolvedContent,
             ) {
-                PrezelChipIcon(icon = icon, size = chipSize)
+                Row(
+                    modifier = Modifier.padding(style.contentPadding(iconOnly = iconOnly)),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    PrezelChipIcon(icon = icon, style = style)
 
-                if (!hasText) return@Row
-                if (hasIcon) {
-                    val spacing = if (chipSize == PrezelChipSize.REGULAR) PrezelTheme.spacing.V4 else PrezelTheme.spacing.V2
-                    Spacer(modifier = Modifier.width(width = spacing))
+                    if (hasText) {
+                        if (hasIcon) {
+                            val spacing = when (style.size) {
+                                PrezelChipSize.REGULAR -> PrezelTheme.spacing.V4
+                                PrezelChipSize.SMALL -> PrezelTheme.spacing.V2
+                            }
+                            Spacer(modifier = Modifier.width(spacing))
+                        }
+                        Text(text = text)
+                    }
                 }
-
-                Text(text = text)
             }
         }
     }
 }
 
 @Composable
-private fun resolveChipBorder(
+private fun PrezelChipIcon(
+    icon: IconSource?,
     style: PrezelChipStyle,
-    hasCustomContainerColor: Boolean,
-): BorderStroke? =
-    if (hasCustomContainerColor) {
-        null
-    } else {
-        prezelChipBorderStroke(
-            type = style.type,
-            interaction = style.interaction,
-            feedback = style.feedback,
-        )
-    }
+    modifier: Modifier = Modifier,
+) {
+    if (icon == null) return
 
-@Composable
-private fun resolveChipContainerColor(
-    style: PrezelChipStyle,
-    iconOnly: Boolean,
-    overrideColor: Color?,
-): Color =
-    overrideColor ?: prezelChipContainerColor(
-        type = style.type,
-        interaction = style.interaction,
-        feedback = style.feedback,
-        iconOnly = iconOnly,
+    Icon(
+        painter = icon.painter(),
+        contentDescription = icon.contentDescription(),
+        modifier = modifier.size(style.iconSize()),
     )
-
-@Composable
-private fun resolveChipContentColor(
-    style: PrezelChipStyle,
-    overrideColor: Color?,
-): Color =
-    overrideColor ?: prezelChipContentColor(
-        interaction = style.interaction,
-        feedback = style.feedback,
-    )
+}
 
 @ThemePreview
 @Composable

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChip.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChip.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import com.team.prezel.core.designsystem.icon.DrawableIcon
 import com.team.prezel.core.designsystem.icon.IconSource
 import com.team.prezel.core.designsystem.icon.PrezelIcons
@@ -45,14 +44,10 @@ fun PrezelChip(
     text: String? = null,
     icon: IconSource? = null,
     style: PrezelChipStyle = PrezelChipStyle(),
-    containerColor: Color = Color.Unspecified,
-    contentColor: Color = Color.Unspecified,
+    customColors: PrezelChipColors = LocalPrezelChipColors.current,
 ) {
     CompositionLocalProvider(
-        LocalPrezelChipColors provides PrezelChipColors(
-            containerColor = containerColor,
-            contentColor = contentColor,
-        ),
+        LocalPrezelChipColors provides customColors,
     ) {
         PrezelChipImpl(
             modifier = modifier,

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChip.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChip.kt
@@ -71,8 +71,8 @@ fun PrezelChip(
     text: String? = null,
     icon: IconSource? = null,
     style: PrezelChipStyle = PrezelChipStyle(),
-    containerColor: Color? = null,
-    contentColor: Color? = null,
+    containerColor: Color = Color.Unspecified,
+    contentColor: Color = Color.Unspecified,
 ) {
     val hasText = text != null
     val hasIcon = icon != null

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChip.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChip.kt
@@ -1,0 +1,144 @@
+package com.team.prezel.core.designsystem.component.chip
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.team.prezel.core.designsystem.foundation.color.PrezelColors
+import com.team.prezel.core.designsystem.icon.DrawableIcon
+import com.team.prezel.core.designsystem.icon.IconSource
+import com.team.prezel.core.designsystem.icon.PrezelIcons
+import com.team.prezel.core.designsystem.preview.PreviewScaffold
+import com.team.prezel.core.designsystem.preview.ThemePreview
+import com.team.prezel.core.designsystem.theme.PrezelTheme
+
+@Composable
+fun PrezelChip(
+    modifier: Modifier = Modifier,
+    text: String? = null,
+    icon: IconSource? = null,
+    style: PrezelChipStyle = PrezelChipStyle(),
+) {
+    val hasText = text != null
+    val hasIcon = icon != null
+    val iconOnly = hasIcon && !hasText
+    require(hasText || hasIcon) { "Chip은 text 또는 icon 중 하나는 반드시 필요합니다." }
+    val (chipType, chipSize, interaction, feedback) = style
+
+    Surface(
+        modifier = modifier,
+        shape = prezelChipShape(chipSize),
+        color = prezelChipContainerColor(type = chipType, interaction = interaction, feedback = feedback, iconOnly = iconOnly),
+        border = prezelChipBorderStroke(type = chipType, interaction = interaction, feedback = feedback),
+    ) {
+        CompositionLocalProvider(
+            LocalTextStyle provides prezelChipTextStyle(chipSize),
+            LocalContentColor provides prezelChipContentColor(interaction = interaction, feedback = feedback),
+        ) {
+            Row(
+                modifier = Modifier.padding(prezelChipContentPadding(size = chipSize, onlyIcon = hasIcon && !hasText)),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                PrezelChipIcon(icon = icon, size = chipSize)
+
+                if (!hasText) return@Row
+                if (hasIcon) {
+                    val spacing = if (chipSize == PrezelChipSize.REGULAR) PrezelTheme.spacing.V4 else PrezelTheme.spacing.V2
+                    Spacer(modifier = Modifier.width(width = spacing))
+                }
+
+                Text(text = text)
+            }
+        }
+    }
+}
+
+@Composable
+fun PrezelChip(
+    containerColor: PrezelColors,
+    contentColor: PrezelColors,
+    modifier: Modifier = Modifier,
+    text: String? = null,
+    icon: IconSource? = null,
+    style: PrezelChipStyle = PrezelChipStyle(),
+) {
+    val hasText = text != null
+    val hasIcon = icon != null
+    val iconOnly = hasIcon && !hasText
+    require(hasText || hasIcon) { "Chip은 text 또는 icon 중 하나는 반드시 필요합니다." }
+    val (chipType, chipSize, interaction, feedback) = style
+
+    Surface(
+        modifier = modifier,
+        shape = prezelChipShape(chipSize),
+        color = prezelChipContainerColor(
+            type = chipType,
+            interaction = interaction,
+            feedback = feedback,
+            iconOnly = iconOnly,
+            colors = containerColor,
+        ),
+        border = prezelChipBorderStroke(type = chipType, interaction = interaction, feedback = feedback),
+    ) {
+        CompositionLocalProvider(
+            LocalTextStyle provides prezelChipTextStyle(chipSize),
+            LocalContentColor provides prezelChipContentColor(interaction = interaction, feedback = feedback, colors = contentColor),
+        ) {
+            Row(
+                modifier = Modifier.padding(prezelChipContentPadding(size = chipSize, onlyIcon = hasIcon && !hasText)),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                PrezelChipIcon(icon = icon, size = chipSize)
+
+                if (!hasText) return@Row
+                if (hasIcon) {
+                    val spacing = if (chipSize == PrezelChipSize.REGULAR) PrezelTheme.spacing.V4 else PrezelTheme.spacing.V2
+                    Spacer(modifier = Modifier.width(width = spacing))
+                }
+
+                Text(text = text)
+            }
+        }
+    }
+}
+
+@ThemePreview
+@Composable
+private fun PrezelChipPreview() {
+    PrezelTheme {
+        PrezelTheme {
+            PreviewScaffold {
+                PrezelChipPreviewByType(
+                    type = PrezelChipType.FILLED,
+                ) { style -> PrezelChipPreviewItem(style) }
+
+                HorizontalDivider()
+
+                PrezelChipPreviewByType(
+                    type = PrezelChipType.OUTLINED,
+                ) { style -> PrezelChipPreviewItem(style) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PrezelChipPreviewItem(style: PrezelChipStyle) {
+    PrezelChip(
+        text = "Label",
+        icon = DrawableIcon(resId = PrezelIcons.Blank),
+        style = style,
+    )
+}

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChip.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChip.kt
@@ -30,41 +30,6 @@ fun PrezelChip(
     icon: IconSource? = null,
     style: PrezelChipStyle = PrezelChipStyle(),
 ) {
-    PrezelChipImpl(
-        modifier = modifier,
-        text = text,
-        icon = icon,
-        style = style,
-    )
-}
-
-@Composable
-fun PrezelChip(
-    modifier: Modifier = Modifier,
-    text: String? = null,
-    icon: IconSource? = null,
-    style: PrezelChipStyle = PrezelChipStyle(),
-    customColors: PrezelChipColors = LocalPrezelChipColors.current,
-) {
-    CompositionLocalProvider(
-        LocalPrezelChipColors provides customColors,
-    ) {
-        PrezelChipImpl(
-            modifier = modifier,
-            text = text,
-            icon = icon,
-            style = style,
-        )
-    }
-}
-
-@Composable
-private fun PrezelChipImpl(
-    modifier: Modifier = Modifier,
-    text: String? = null,
-    icon: IconSource? = null,
-    style: PrezelChipStyle = PrezelChipStyle(),
-) {
     val hasText = text != null
     val hasIcon = icon != null
     val iconOnly = hasIcon && !hasText
@@ -95,6 +60,26 @@ private fun PrezelChipImpl(
                 }
             }
         }
+    }
+}
+
+@Composable
+fun PrezelChip(
+    modifier: Modifier = Modifier,
+    text: String? = null,
+    icon: IconSource? = null,
+    style: PrezelChipStyle = PrezelChipStyle(),
+    customColors: PrezelChipColors = LocalPrezelChipColors.current,
+) {
+    CompositionLocalProvider(
+        LocalPrezelChipColors provides customColors,
+    ) {
+        PrezelChip(
+            modifier = modifier,
+            text = text,
+            icon = icon,
+            style = style,
+        )
     }
 }
 

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChip.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChip.kt
@@ -1,5 +1,6 @@
 package com.team.prezel.core.designsystem.component.chip
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -14,7 +15,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.team.prezel.core.designsystem.foundation.color.PrezelColors
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 import com.team.prezel.core.designsystem.icon.DrawableIcon
 import com.team.prezel.core.designsystem.icon.IconSource
 import com.team.prezel.core.designsystem.icon.PrezelIcons
@@ -66,12 +68,12 @@ fun PrezelChip(
 
 @Composable
 fun PrezelChip(
-    containerColor: PrezelColors,
-    contentColor: PrezelColors,
     modifier: Modifier = Modifier,
     text: String? = null,
     icon: IconSource? = null,
     style: PrezelChipStyle = PrezelChipStyle(),
+    containerColor: Color? = null,
+    contentColor: Color? = null,
 ) {
     val hasText = text != null
     val hasIcon = icon != null
@@ -79,21 +81,39 @@ fun PrezelChip(
     require(hasText || hasIcon) { "Chip은 text 또는 icon 중 하나는 반드시 필요합니다." }
     val (chipType, chipSize, interaction, feedback) = style
 
-    Surface(
-        modifier = modifier,
-        shape = prezelChipShape(chipSize),
-        color = prezelChipContainerColor(
+    val resolvedContainerColor =
+        containerColor ?: prezelChipContainerColor(
             type = chipType,
             interaction = interaction,
             feedback = feedback,
             iconOnly = iconOnly,
-            colors = containerColor,
-        ),
-        border = prezelChipBorderStroke(type = chipType, interaction = interaction, feedback = feedback),
+        )
+
+    val resolvedContentColor = contentColor ?: prezelChipContentColor(
+        interaction = interaction,
+        feedback = feedback,
+    )
+
+    val resolvedBorder =
+        if (containerColor != null) {
+            BorderStroke(0.dp, Color.Transparent)
+        } else {
+            prezelChipBorderStroke(
+                type = chipType,
+                interaction = interaction,
+                feedback = feedback,
+            )
+        }
+
+    Surface(
+        modifier = modifier,
+        shape = prezelChipShape(chipSize),
+        color = resolvedContainerColor,
+        border = resolvedBorder,
     ) {
         CompositionLocalProvider(
             LocalTextStyle provides prezelChipTextStyle(chipSize),
-            LocalContentColor provides prezelChipContentColor(interaction = interaction, feedback = feedback, colors = contentColor),
+            LocalContentColor provides resolvedContentColor,
         ) {
             Row(
                 modifier = Modifier.padding(prezelChipContentPadding(size = chipSize, onlyIcon = hasIcon && !hasText)),

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChip.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChip.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
 import com.team.prezel.core.designsystem.icon.DrawableIcon
 import com.team.prezel.core.designsystem.icon.IconSource
 import com.team.prezel.core.designsystem.icon.PrezelIcons
@@ -79,31 +78,26 @@ fun PrezelChip(
     val hasIcon = icon != null
     val iconOnly = hasIcon && !hasText
     require(hasText || hasIcon) { "Chip은 text 또는 icon 중 하나는 반드시 필요합니다." }
-    val (chipType, chipSize, interaction, feedback) = style
-
-    val resolvedContainerColor =
-        containerColor ?: prezelChipContainerColor(
-            type = chipType,
-            interaction = interaction,
-            feedback = feedback,
-            iconOnly = iconOnly,
-        )
-
-    val resolvedContentColor = contentColor ?: prezelChipContentColor(
-        interaction = interaction,
-        feedback = feedback,
-    )
+    val (_, chipSize, _, _) = style
 
     val resolvedBorder =
-        if (containerColor != null) {
-            BorderStroke(0.dp, Color.Transparent)
-        } else {
-            prezelChipBorderStroke(
-                type = chipType,
-                interaction = interaction,
-                feedback = feedback,
-            )
-        }
+        resolveChipBorder(
+            style = style,
+            hasCustomContainerColor = containerColor != null,
+        )
+
+    val resolvedContainerColor =
+        resolveChipContainerColor(
+            style = style,
+            iconOnly = iconOnly,
+            overrideColor = containerColor,
+        )
+
+    val resolvedContentColor =
+        resolveChipContentColor(
+            style = style,
+            overrideColor = contentColor,
+        )
 
     Surface(
         modifier = modifier,
@@ -133,6 +127,44 @@ fun PrezelChip(
         }
     }
 }
+
+@Composable
+private fun resolveChipBorder(
+    style: PrezelChipStyle,
+    hasCustomContainerColor: Boolean,
+): BorderStroke? =
+    if (hasCustomContainerColor) {
+        null
+    } else {
+        prezelChipBorderStroke(
+            type = style.type,
+            interaction = style.interaction,
+            feedback = style.feedback,
+        )
+    }
+
+@Composable
+private fun resolveChipContainerColor(
+    style: PrezelChipStyle,
+    iconOnly: Boolean,
+    overrideColor: Color?,
+): Color =
+    overrideColor ?: prezelChipContainerColor(
+        type = style.type,
+        interaction = style.interaction,
+        feedback = style.feedback,
+        iconOnly = iconOnly,
+    )
+
+@Composable
+private fun resolveChipContentColor(
+    style: PrezelChipStyle,
+    overrideColor: Color?,
+): Color =
+    overrideColor ?: prezelChipContentColor(
+        interaction = style.interaction,
+        feedback = style.feedback,
+    )
 
 @ThemePreview
 @Composable

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChip.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChip.kt
@@ -31,11 +31,49 @@ fun PrezelChip(
     icon: IconSource? = null,
     style: PrezelChipStyle = PrezelChipStyle(),
 ) {
+    PrezelChipImpl(
+        modifier = modifier,
+        text = text,
+        icon = icon,
+        style = style,
+    )
+}
+
+@Composable
+fun PrezelChip(
+    modifier: Modifier = Modifier,
+    text: String? = null,
+    icon: IconSource? = null,
+    style: PrezelChipStyle = PrezelChipStyle(),
+    containerColor: Color = Color.Unspecified,
+    contentColor: Color = Color.Unspecified,
+) {
+    CompositionLocalProvider(
+        LocalPrezelChipColors provides PrezelChipColors(
+            containerColor = containerColor,
+            contentColor = contentColor,
+        ),
+    ) {
+        PrezelChipImpl(
+            modifier = modifier,
+            text = text,
+            icon = icon,
+            style = style,
+        )
+    }
+}
+
+@Composable
+private fun PrezelChipImpl(
+    modifier: Modifier = Modifier,
+    text: String? = null,
+    icon: IconSource? = null,
+    style: PrezelChipStyle = PrezelChipStyle(),
+) {
     val hasText = text != null
     val hasIcon = icon != null
     val iconOnly = hasIcon && !hasText
     require(hasText || hasIcon) { "Chip은 text 또는 icon 중 하나는 반드시 필요합니다." }
-    val (_, chipSize, _, _) = style
 
     Surface(
         modifier = modifier,
@@ -54,69 +92,11 @@ fun PrezelChip(
             ) {
                 PrezelChipIcon(icon = icon, style = style)
 
-                if (!hasText) return@Row
-                if (hasIcon) {
-                    val spacing = if (chipSize == PrezelChipSize.REGULAR) PrezelTheme.spacing.V4 else PrezelTheme.spacing.V2
-                    Spacer(modifier = Modifier.width(width = spacing))
-                }
-
-                Text(text = text)
-            }
-        }
-    }
-}
-
-@Composable
-fun PrezelChip(
-    modifier: Modifier = Modifier,
-    text: String? = null,
-    icon: IconSource? = null,
-    style: PrezelChipStyle = PrezelChipStyle(),
-    containerColor: Color = Color.Unspecified,
-    contentColor: Color = Color.Unspecified,
-) {
-    val hasText = text != null
-    val hasIcon = icon != null
-    val iconOnly = hasIcon && !hasText
-    require(hasText || hasIcon) { "Chip은 text 또는 icon 중 하나는 반드시 필요합니다." }
-
-    val colors = PrezelChipColors(
-        containerColor = containerColor,
-        contentColor = contentColor,
-    )
-
-    CompositionLocalProvider(LocalPrezelChipColors provides colors) {
-        val resolvedContainer = style.containerColor(iconOnly = iconOnly)
-        val resolvedContent = style.contentColor()
-        val resolvedBorder = style.borderStroke()
-
-        Surface(
-            modifier = modifier,
-            shape = style.shape(),
-            color = resolvedContainer,
-            border = resolvedBorder,
-        ) {
-            CompositionLocalProvider(
-                LocalTextStyle provides style.textStyle(),
-                LocalContentColor provides resolvedContent,
-            ) {
-                Row(
-                    modifier = Modifier.padding(style.contentPadding(iconOnly = iconOnly)),
-                    horizontalArrangement = Arrangement.Center,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    PrezelChipIcon(icon = icon, style = style)
-
-                    if (hasText) {
-                        if (hasIcon) {
-                            val spacing = when (style.size) {
-                                PrezelChipSize.REGULAR -> PrezelTheme.spacing.V4
-                                PrezelChipSize.SMALL -> PrezelTheme.spacing.V2
-                            }
-                            Spacer(modifier = Modifier.width(spacing))
-                        }
-                        Text(text = text)
+                if (hasText) {
+                    if (hasIcon) {
+                        Spacer(modifier = Modifier.width(style.iconTextSpacing()))
                     }
+                    Text(text = text)
                 }
             }
         }
@@ -142,18 +122,16 @@ private fun PrezelChipIcon(
 @Composable
 private fun PrezelChipPreview() {
     PrezelTheme {
-        PrezelTheme {
-            PreviewScaffold {
-                PrezelChipPreviewByType(
-                    type = PrezelChipType.FILLED,
-                ) { style -> PrezelChipPreviewItem(style) }
+        PreviewScaffold {
+            PrezelChipPreviewByType(
+                type = PrezelChipType.FILLED,
+            ) { style -> PrezelChipPreviewItem(style) }
 
-                HorizontalDivider()
+            HorizontalDivider()
 
-                PrezelChipPreviewByType(
-                    type = PrezelChipType.OUTLINED,
-                ) { style -> PrezelChipPreviewItem(style) }
-            }
+            PrezelChipPreviewByType(
+                type = PrezelChipType.OUTLINED,
+            ) { style -> PrezelChipPreviewItem(style) }
         }
     }
 }

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChipPreview.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChipPreview.kt
@@ -1,0 +1,130 @@
+package com.team.prezel.core.designsystem.component.chip
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.team.prezel.core.designsystem.theme.PrezelTheme
+import kotlinx.collections.immutable.persistentListOf
+
+internal typealias PrezelChipPreviewContent = @Composable (PrezelChipStyle) -> Unit
+
+private val DefaultInteractionVariants = persistentListOf(
+    PrezelChipInteraction.DEFAULT,
+    PrezelChipInteraction.ACTIVE,
+    PrezelChipInteraction.DISABLED,
+)
+
+private val PreviewSizes = persistentListOf(
+    PrezelChipSize.SMALL,
+    PrezelChipSize.REGULAR,
+)
+
+@Composable
+internal fun PrezelChipPreviewByType(
+    type: PrezelChipType,
+    content: PrezelChipPreviewContent,
+) {
+    Text(
+        text = type.name,
+        style = PrezelTheme.typography.title2Medium,
+    )
+
+    HorizontalDivider()
+
+    PrezelChipBadSection(
+        type = type,
+        content = content,
+    )
+
+    HorizontalDivider()
+
+    PrezelChipDefaultSection(
+        type = type,
+        content = content,
+    )
+}
+
+@Composable
+private fun PrezelChipBadSection(
+    type: PrezelChipType,
+    content: PrezelChipPreviewContent,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = "Feedback: BAD",
+            style = PrezelTheme.typography.body2Medium,
+        )
+
+        PrezelChipPreviewBlock(
+            type = type,
+            feedback = PrezelChipFeedback.BAD,
+            interaction = PrezelChipInteraction.DEFAULT,
+            content = content,
+        )
+    }
+}
+
+@Composable
+private fun PrezelChipDefaultSection(
+    type: PrezelChipType,
+    content: PrezelChipPreviewContent,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = "Feedback: DEFAULT",
+            style = PrezelTheme.typography.body2Medium,
+        )
+
+        DefaultInteractionVariants.forEach { interaction ->
+            Text(
+                text = "Interaction: $interaction",
+                style = PrezelTheme.typography.body3Medium,
+            )
+
+            PrezelChipPreviewBlock(
+                type = type,
+                feedback = PrezelChipFeedback.DEFAULT,
+                interaction = interaction,
+                content = content,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PrezelChipPreviewBlock(
+    type: PrezelChipType,
+    interaction: PrezelChipInteraction,
+    feedback: PrezelChipFeedback,
+    content: PrezelChipPreviewContent,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        PreviewSizes.forEach { size ->
+            content(
+                PrezelChipStyle(
+                    type = type,
+                    size = size,
+                    interaction = interaction,
+                    feedback = feedback,
+                ),
+            )
+        }
+    }
+}

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChipStyle.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChipStyle.kt
@@ -17,6 +17,8 @@ import com.team.prezel.core.designsystem.foundation.number.PrezelStroke
 import com.team.prezel.core.designsystem.foundation.typography.PrezelTypography
 import com.team.prezel.core.designsystem.theme.PrezelTheme
 
+internal val LocalPrezelChipColors = staticCompositionLocalOf { PrezelChipColors() }
+
 enum class PrezelChipType {
     FILLED,
     OUTLINED,
@@ -37,6 +39,12 @@ enum class PrezelChipSize {
     SMALL,
     REGULAR,
 }
+
+@Immutable
+data class PrezelChipColors(
+    val containerColor: Color = Color.Unspecified,
+    val contentColor: Color = Color.Unspecified,
+)
 
 @Immutable
 data class PrezelChipStyle(
@@ -158,11 +166,3 @@ data class PrezelChipStyle(
             PrezelChipSize.REGULAR -> 16.dp
         }
 }
-
-@Immutable
-data class PrezelChipColors(
-    val containerColor: Color = Color.Unspecified,
-    val contentColor: Color = Color.Unspecified,
-)
-
-internal val LocalPrezelChipColors = staticCompositionLocalOf { PrezelChipColors() }

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChipStyle.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChipStyle.kt
@@ -1,0 +1,209 @@
+package com.team.prezel.core.designsystem.component.chip
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import com.team.prezel.core.designsystem.foundation.color.PrezelColors
+import com.team.prezel.core.designsystem.foundation.number.PrezelShapes
+import com.team.prezel.core.designsystem.foundation.number.PrezelSpacing
+import com.team.prezel.core.designsystem.foundation.number.PrezelStroke
+import com.team.prezel.core.designsystem.icon.IconSource
+import com.team.prezel.core.designsystem.theme.PrezelTheme
+
+enum class PrezelChipType {
+    FILLED,
+    OUTLINED,
+}
+
+enum class PrezelChipInteraction {
+    DEFAULT,
+    ACTIVE,
+    DISABLED,
+}
+
+enum class PrezelChipFeedback {
+    DEFAULT,
+    BAD,
+}
+
+enum class PrezelChipSize {
+    SMALL,
+    REGULAR,
+}
+
+@Immutable
+data class PrezelChipStyle(
+    val type: PrezelChipType = PrezelChipType.FILLED,
+    val size: PrezelChipSize = PrezelChipSize.REGULAR,
+    val interaction: PrezelChipInteraction = PrezelChipInteraction.DEFAULT,
+    val feedback: PrezelChipFeedback = PrezelChipFeedback.DEFAULT,
+)
+
+@Composable
+internal fun PrezelChipIcon(
+    icon: IconSource?,
+    size: PrezelChipSize,
+    modifier: Modifier = Modifier,
+) {
+    if (icon == null) return
+
+    Icon(
+        painter = icon.painter(),
+        contentDescription = icon.contentDescription(),
+        modifier = modifier.size(
+            when (size) {
+                PrezelChipSize.SMALL -> 12.dp
+                PrezelChipSize.REGULAR -> 14.dp
+            },
+        ),
+    )
+}
+
+@Composable
+internal fun prezelChipShape(
+    size: PrezelChipSize,
+    shapes: PrezelShapes = PrezelTheme.shapes,
+): Shape =
+    when (size) {
+        PrezelChipSize.SMALL -> shapes.V4
+        PrezelChipSize.REGULAR -> shapes.V8
+    }
+
+@Composable
+internal fun prezelChipBorderStroke(
+    type: PrezelChipType,
+    interaction: PrezelChipInteraction,
+    feedback: PrezelChipFeedback,
+    colors: PrezelColors = PrezelTheme.colors,
+    stroke: PrezelStroke = PrezelTheme.stroke,
+): BorderStroke {
+    if (type == PrezelChipType.FILLED) return BorderStroke(0.dp, Color.Transparent)
+
+    val borderColor =
+        when {
+            feedback == PrezelChipFeedback.BAD -> {
+                colors.feedbackBadRegular
+            }
+
+            interaction == PrezelChipInteraction.ACTIVE -> {
+                colors.interactiveRegular
+            }
+
+            interaction == PrezelChipInteraction.DISABLED -> {
+                colors.borderRegular
+            }
+
+            else -> {
+                colors.borderMedium
+            }
+        }
+
+    return BorderStroke(
+        width = stroke.V1,
+        color = borderColor,
+    )
+}
+
+@Composable
+internal fun prezelChipTextStyle(size: PrezelChipSize): TextStyle =
+    when (size) {
+        PrezelChipSize.SMALL -> PrezelTheme.typography.caption2Regular
+        PrezelChipSize.REGULAR -> PrezelTheme.typography.caption1Regular
+    }
+
+@Composable
+internal fun prezelChipContainerColor(
+    type: PrezelChipType,
+    interaction: PrezelChipInteraction,
+    feedback: PrezelChipFeedback,
+    iconOnly: Boolean,
+    colors: PrezelColors = PrezelTheme.colors,
+): Color {
+    if (type == PrezelChipType.OUTLINED && iconOnly) {
+        return Color.Transparent
+    }
+
+    return when {
+        feedback == PrezelChipFeedback.BAD -> {
+            colors.feedbackBadSmall
+        }
+
+        interaction == PrezelChipInteraction.ACTIVE -> {
+            colors.interactiveXSmall
+        }
+
+        interaction == PrezelChipInteraction.DISABLED -> {
+            colors.bgLarge
+        }
+
+        else -> {
+            when (type) {
+                PrezelChipType.FILLED -> colors.bgMedium
+                PrezelChipType.OUTLINED -> colors.bgRegular
+            }
+        }
+    }
+}
+
+@Composable
+internal fun prezelChipContentColor(
+    interaction: PrezelChipInteraction,
+    feedback: PrezelChipFeedback,
+    colors: PrezelColors = PrezelTheme.colors,
+): Color =
+    when {
+        feedback == PrezelChipFeedback.BAD -> {
+            colors.feedbackBadRegular
+        }
+
+        interaction == PrezelChipInteraction.ACTIVE -> {
+            colors.interactiveRegular
+        }
+
+        interaction == PrezelChipInteraction.DISABLED -> {
+            colors.iconDisabled
+        }
+
+        else -> {
+            colors.iconRegular
+        }
+    }
+
+@Composable
+internal fun prezelChipContentPadding(
+    size: PrezelChipSize,
+    onlyIcon: Boolean = false,
+    spacing: PrezelSpacing = PrezelTheme.spacing,
+): PaddingValues {
+    if (onlyIcon) return prezelIconChipContentPadding(size)
+
+    val horizontal = when (size) {
+        PrezelChipSize.SMALL -> spacing.V6
+        PrezelChipSize.REGULAR -> spacing.V8
+    }
+
+    val vertical = when (size) {
+        PrezelChipSize.SMALL -> spacing.V4
+        PrezelChipSize.REGULAR -> spacing.V6
+    }
+
+    return PaddingValues(horizontal = horizontal, vertical = vertical)
+}
+
+@Composable
+private fun prezelIconChipContentPadding(
+    size: PrezelChipSize,
+    spacing: PrezelSpacing = PrezelTheme.spacing,
+): PaddingValues =
+    when (size) {
+        PrezelChipSize.SMALL -> spacing.V6
+        PrezelChipSize.REGULAR -> spacing.V8
+    }.let { spacing -> PaddingValues(all = spacing) }

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChipStyle.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChipStyle.kt
@@ -60,8 +60,8 @@ internal fun PrezelChipIcon(
         contentDescription = icon.contentDescription(),
         modifier = modifier.size(
             when (size) {
-                PrezelChipSize.SMALL -> 12.dp
-                PrezelChipSize.REGULAR -> 14.dp
+                PrezelChipSize.SMALL -> 14.dp
+                PrezelChipSize.REGULAR -> 16.dp
             },
         ),
     )

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChipStyle.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChipStyle.kt
@@ -2,20 +2,19 @@ package com.team.prezel.core.designsystem.component.chip
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
-import androidx.compose.ui.Modifier
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.team.prezel.core.designsystem.foundation.color.PrezelColors
 import com.team.prezel.core.designsystem.foundation.number.PrezelShapes
 import com.team.prezel.core.designsystem.foundation.number.PrezelSpacing
 import com.team.prezel.core.designsystem.foundation.number.PrezelStroke
-import com.team.prezel.core.designsystem.icon.IconSource
+import com.team.prezel.core.designsystem.foundation.typography.PrezelTypography
 import com.team.prezel.core.designsystem.theme.PrezelTheme
 
 enum class PrezelChipType {
@@ -45,49 +44,86 @@ data class PrezelChipStyle(
     val size: PrezelChipSize = PrezelChipSize.REGULAR,
     val interaction: PrezelChipInteraction = PrezelChipInteraction.DEFAULT,
     val feedback: PrezelChipFeedback = PrezelChipFeedback.DEFAULT,
-)
-
-@Composable
-internal fun PrezelChipIcon(
-    icon: IconSource?,
-    size: PrezelChipSize,
-    modifier: Modifier = Modifier,
 ) {
-    if (icon == null) return
+    @Composable
+    internal fun shape(shapes: PrezelShapes = PrezelTheme.shapes): Shape =
+        when (size) {
+            PrezelChipSize.SMALL -> shapes.V4
+            PrezelChipSize.REGULAR -> shapes.V8
+        }
 
-    Icon(
-        painter = icon.painter(),
-        contentDescription = icon.contentDescription(),
-        modifier = modifier.size(
-            when (size) {
-                PrezelChipSize.SMALL -> 14.dp
-                PrezelChipSize.REGULAR -> 16.dp
-            },
-        ),
-    )
-}
+    @Composable
+    internal fun borderStroke(
+        colors: PrezelColors = PrezelTheme.colors,
+        stroke: PrezelStroke = PrezelTheme.stroke,
+    ): BorderStroke? {
+        if (type == PrezelChipType.FILLED) return null
 
-@Composable
-internal fun prezelChipShape(
-    size: PrezelChipSize,
-    shapes: PrezelShapes = PrezelTheme.shapes,
-): Shape =
-    when (size) {
-        PrezelChipSize.SMALL -> shapes.V4
-        PrezelChipSize.REGULAR -> shapes.V8
+        val borderColor =
+            when {
+                feedback == PrezelChipFeedback.BAD -> {
+                    colors.feedbackBadRegular
+                }
+
+                interaction == PrezelChipInteraction.ACTIVE -> {
+                    colors.interactiveRegular
+                }
+
+                interaction == PrezelChipInteraction.DISABLED -> {
+                    colors.borderRegular
+                }
+
+                else -> {
+                    colors.borderMedium
+                }
+            }
+
+        return BorderStroke(
+            width = stroke.V1,
+            color = borderColor,
+        )
     }
 
-@Composable
-internal fun prezelChipBorderStroke(
-    type: PrezelChipType,
-    interaction: PrezelChipInteraction,
-    feedback: PrezelChipFeedback,
-    colors: PrezelColors = PrezelTheme.colors,
-    stroke: PrezelStroke = PrezelTheme.stroke,
-): BorderStroke {
-    if (type == PrezelChipType.FILLED) return BorderStroke(0.dp, Color.Transparent)
+    @Composable
+    internal fun textStyle(typography: PrezelTypography = PrezelTheme.typography): TextStyle =
+        when (size) {
+            PrezelChipSize.SMALL -> typography.caption2Regular
+            PrezelChipSize.REGULAR -> typography.caption1Regular
+        }
 
-    val borderColor =
+    @Composable
+    internal fun containerColor(
+        iconOnly: Boolean,
+        colors: PrezelColors = PrezelTheme.colors,
+    ): Color {
+        if (type == PrezelChipType.OUTLINED && iconOnly) {
+            return Color.Transparent
+        }
+
+        return when {
+            feedback == PrezelChipFeedback.BAD -> {
+                colors.feedbackBadSmall
+            }
+
+            interaction == PrezelChipInteraction.ACTIVE -> {
+                colors.interactiveXSmall
+            }
+
+            interaction == PrezelChipInteraction.DISABLED -> {
+                colors.bgLarge
+            }
+
+            else -> {
+                when (type) {
+                    PrezelChipType.FILLED -> colors.bgMedium
+                    PrezelChipType.OUTLINED -> colors.bgRegular
+                }
+            }
+        }
+    }
+
+    @Composable
+    internal fun contentColor(colors: PrezelColors = PrezelTheme.colors): Color =
         when {
             feedback == PrezelChipFeedback.BAD -> {
                 colors.feedbackBadRegular
@@ -98,112 +134,51 @@ internal fun prezelChipBorderStroke(
             }
 
             interaction == PrezelChipInteraction.DISABLED -> {
-                colors.borderRegular
+                colors.iconDisabled
             }
 
             else -> {
-                colors.borderMedium
+                colors.iconRegular
             }
         }
 
-    return BorderStroke(
-        width = stroke.V1,
-        color = borderColor,
-    )
-}
-
-@Composable
-internal fun prezelChipTextStyle(size: PrezelChipSize): TextStyle =
-    when (size) {
-        PrezelChipSize.SMALL -> PrezelTheme.typography.caption2Regular
-        PrezelChipSize.REGULAR -> PrezelTheme.typography.caption1Regular
-    }
-
-@Composable
-internal fun prezelChipContainerColor(
-    type: PrezelChipType,
-    interaction: PrezelChipInteraction,
-    feedback: PrezelChipFeedback,
-    iconOnly: Boolean,
-    colors: PrezelColors = PrezelTheme.colors,
-): Color {
-    if (type == PrezelChipType.OUTLINED && iconOnly) {
-        return Color.Transparent
-    }
-
-    return when {
-        feedback == PrezelChipFeedback.BAD -> {
-            colors.feedbackBadSmall
-        }
-
-        interaction == PrezelChipInteraction.ACTIVE -> {
-            colors.interactiveXSmall
-        }
-
-        interaction == PrezelChipInteraction.DISABLED -> {
-            colors.bgLarge
-        }
-
-        else -> {
-            when (type) {
-                PrezelChipType.FILLED -> colors.bgMedium
-                PrezelChipType.OUTLINED -> colors.bgRegular
+    @Composable
+    internal fun contentPadding(
+        iconOnly: Boolean,
+        spacing: PrezelSpacing = PrezelTheme.spacing,
+    ): PaddingValues {
+        if (iconOnly) {
+            val all = when (size) {
+                PrezelChipSize.SMALL -> spacing.V6
+                PrezelChipSize.REGULAR -> spacing.V8
             }
+            return PaddingValues(all = all)
         }
+
+        val horizontal = when (size) {
+            PrezelChipSize.SMALL -> spacing.V6
+            PrezelChipSize.REGULAR -> spacing.V8
+        }
+
+        val vertical = when (size) {
+            PrezelChipSize.SMALL -> spacing.V4
+            PrezelChipSize.REGULAR -> spacing.V6
+        }
+
+        return PaddingValues(horizontal = horizontal, vertical = vertical)
     }
+
+    internal fun iconSize(): Dp =
+        when (size) {
+            PrezelChipSize.SMALL -> 14.dp
+            PrezelChipSize.REGULAR -> 16.dp
+        }
 }
 
-@Composable
-internal fun prezelChipContentColor(
-    interaction: PrezelChipInteraction,
-    feedback: PrezelChipFeedback,
-    colors: PrezelColors = PrezelTheme.colors,
-): Color =
-    when {
-        feedback == PrezelChipFeedback.BAD -> {
-            colors.feedbackBadRegular
-        }
+@Immutable
+data class PrezelChipColors(
+    val containerColor: Color = Color.Unspecified,
+    val contentColor: Color = Color.Unspecified,
+)
 
-        interaction == PrezelChipInteraction.ACTIVE -> {
-            colors.interactiveRegular
-        }
-
-        interaction == PrezelChipInteraction.DISABLED -> {
-            colors.iconDisabled
-        }
-
-        else -> {
-            colors.iconRegular
-        }
-    }
-
-@Composable
-internal fun prezelChipContentPadding(
-    size: PrezelChipSize,
-    onlyIcon: Boolean = false,
-    spacing: PrezelSpacing = PrezelTheme.spacing,
-): PaddingValues {
-    if (onlyIcon) return prezelIconChipContentPadding(size)
-
-    val horizontal = when (size) {
-        PrezelChipSize.SMALL -> spacing.V6
-        PrezelChipSize.REGULAR -> spacing.V8
-    }
-
-    val vertical = when (size) {
-        PrezelChipSize.SMALL -> spacing.V4
-        PrezelChipSize.REGULAR -> spacing.V6
-    }
-
-    return PaddingValues(horizontal = horizontal, vertical = vertical)
-}
-
-@Composable
-private fun prezelIconChipContentPadding(
-    size: PrezelChipSize,
-    spacing: PrezelSpacing = PrezelTheme.spacing,
-): PaddingValues =
-    when (size) {
-        PrezelChipSize.SMALL -> spacing.V6
-        PrezelChipSize.REGULAR -> spacing.V8
-    }.let { spacing -> PaddingValues(all = spacing) }
+internal val LocalPrezelChipColors = staticCompositionLocalOf { PrezelChipColors() }

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChipStyle.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelChipStyle.kt
@@ -56,26 +56,17 @@ data class PrezelChipStyle(
     internal fun borderStroke(
         colors: PrezelColors = PrezelTheme.colors,
         stroke: PrezelStroke = PrezelTheme.stroke,
+        chipColors: PrezelChipColors = LocalPrezelChipColors.current,
     ): BorderStroke? {
         if (type == PrezelChipType.FILLED) return null
 
         val borderColor =
             when {
-                feedback == PrezelChipFeedback.BAD -> {
-                    colors.feedbackBadRegular
-                }
-
-                interaction == PrezelChipInteraction.ACTIVE -> {
-                    colors.interactiveRegular
-                }
-
-                interaction == PrezelChipInteraction.DISABLED -> {
-                    colors.borderRegular
-                }
-
-                else -> {
-                    colors.borderMedium
-                }
+                chipColors.contentColor != Color.Unspecified -> chipColors.contentColor
+                feedback == PrezelChipFeedback.BAD -> colors.feedbackBadRegular
+                interaction == PrezelChipInteraction.ACTIVE -> colors.interactiveRegular
+                interaction == PrezelChipInteraction.DISABLED -> colors.borderRegular
+                else -> colors.borderMedium
             }
 
         return BorderStroke(
@@ -95,24 +86,17 @@ data class PrezelChipStyle(
     internal fun containerColor(
         iconOnly: Boolean,
         colors: PrezelColors = PrezelTheme.colors,
+        chipColors: PrezelChipColors = LocalPrezelChipColors.current,
     ): Color {
         if (type == PrezelChipType.OUTLINED && iconOnly) {
             return Color.Transparent
         }
 
         return when {
-            feedback == PrezelChipFeedback.BAD -> {
-                colors.feedbackBadSmall
-            }
-
-            interaction == PrezelChipInteraction.ACTIVE -> {
-                colors.interactiveXSmall
-            }
-
-            interaction == PrezelChipInteraction.DISABLED -> {
-                colors.bgLarge
-            }
-
+            chipColors.containerColor != Color.Unspecified -> chipColors.containerColor
+            feedback == PrezelChipFeedback.BAD -> colors.feedbackBadSmall
+            interaction == PrezelChipInteraction.ACTIVE -> colors.interactiveXSmall
+            interaction == PrezelChipInteraction.DISABLED -> colors.bgLarge
             else -> {
                 when (type) {
                     PrezelChipType.FILLED -> colors.bgMedium
@@ -123,23 +107,16 @@ data class PrezelChipStyle(
     }
 
     @Composable
-    internal fun contentColor(colors: PrezelColors = PrezelTheme.colors): Color =
+    internal fun contentColor(
+        colors: PrezelColors = PrezelTheme.colors,
+        chipColors: PrezelChipColors = LocalPrezelChipColors.current,
+    ): Color =
         when {
-            feedback == PrezelChipFeedback.BAD -> {
-                colors.feedbackBadRegular
-            }
-
-            interaction == PrezelChipInteraction.ACTIVE -> {
-                colors.interactiveRegular
-            }
-
-            interaction == PrezelChipInteraction.DISABLED -> {
-                colors.iconDisabled
-            }
-
-            else -> {
-                colors.iconRegular
-            }
+            chipColors.contentColor != Color.Unspecified -> chipColors.contentColor
+            feedback == PrezelChipFeedback.BAD -> colors.feedbackBadRegular
+            interaction == PrezelChipInteraction.ACTIVE -> colors.interactiveRegular
+            interaction == PrezelChipInteraction.DISABLED -> colors.iconDisabled
+            else -> colors.iconRegular
         }
 
     @Composable
@@ -167,6 +144,13 @@ data class PrezelChipStyle(
 
         return PaddingValues(horizontal = horizontal, vertical = vertical)
     }
+
+    @Composable
+    internal fun iconTextSpacing(spacing: PrezelSpacing = PrezelTheme.spacing): Dp =
+        when (size) {
+            PrezelChipSize.REGULAR -> spacing.V4
+            PrezelChipSize.SMALL -> spacing.V2
+        }
 
     internal fun iconSize(): Dp =
         when (size) {

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelCustomChipPreview.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelCustomChipPreview.kt
@@ -1,0 +1,170 @@
+package com.team.prezel.core.designsystem.component.chip
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.team.prezel.core.designsystem.icon.DrawableIcon
+import com.team.prezel.core.designsystem.icon.PrezelIcons
+import com.team.prezel.core.designsystem.preview.PreviewScaffold
+import com.team.prezel.core.designsystem.preview.ThemePreview
+import com.team.prezel.core.designsystem.theme.PrezelTheme
+
+@ThemePreview
+@Composable
+private fun PrezelChip_CustomColors_Preview() {
+    PrezelTheme {
+        PreviewScaffold {
+            CustomChipHeader()
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            CustomChipLabelSection()
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            CustomChipIconOnlySection()
+        }
+    }
+}
+
+@Composable
+private fun CustomChipHeader() {
+    Text(
+        text = "Custom Chip",
+        style = PrezelTheme.typography.title2Medium,
+    )
+}
+
+@Composable
+private fun CustomChipLabelSection() {
+    FlowRow(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        maxItemsInEachRow = 3,
+    ) {
+        CustomYellowLabelChip()
+        CustomRedLabelChip()
+        CustomGreenLabelChip()
+    }
+}
+
+@Composable
+private fun CustomChipIconOnlySection() {
+    Text(
+        text = "Icon only",
+        style = PrezelTheme.typography.body3Medium,
+    )
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        CustomYellowIconChip()
+        CustomRedIconChip()
+        CustomGreenIconChip()
+    }
+}
+
+@Composable
+private fun CustomYellowLabelChip() {
+    PrezelChip(
+        text = "느려요",
+        icon = DrawableIcon(resId = PrezelIcons.Blank),
+        style = PrezelChipStyle(
+            type = PrezelChipType.FILLED,
+            size = PrezelChipSize.REGULAR,
+            interaction = PrezelChipInteraction.DISABLED,
+            feedback = PrezelChipFeedback.BAD,
+        ),
+        containerColor = PrezelTheme.colors.feedbackWarningSmall,
+        contentColor = PrezelTheme.colors.feedbackWarningRegular,
+    )
+}
+
+@Composable
+private fun CustomRedLabelChip() {
+    PrezelChip(
+        text = "빨라요",
+        icon = null,
+        style = PrezelChipStyle(
+            type = PrezelChipType.OUTLINED,
+            size = PrezelChipSize.REGULAR,
+            interaction = PrezelChipInteraction.DEFAULT,
+            feedback = PrezelChipFeedback.DEFAULT,
+        ),
+        containerColor = PrezelTheme.colors.feedbackBadSmall,
+        contentColor = PrezelTheme.colors.feedbackBadRegular,
+    )
+}
+
+@Composable
+private fun CustomGreenLabelChip() {
+    PrezelChip(
+        text = "적당해요",
+        icon = null,
+        style = PrezelChipStyle(
+            type = PrezelChipType.FILLED,
+            size = PrezelChipSize.SMALL,
+            interaction = PrezelChipInteraction.ACTIVE,
+            feedback = PrezelChipFeedback.DEFAULT,
+        ),
+        containerColor = Color(0xFFDBFFF6),
+        contentColor = Color(0xFF00A37A),
+    )
+}
+
+@Composable
+private fun CustomYellowIconChip() {
+    PrezelChip(
+        text = null,
+        icon = DrawableIcon(resId = PrezelIcons.Blank),
+        style = PrezelChipStyle(
+            type = PrezelChipType.FILLED,
+            size = PrezelChipSize.REGULAR,
+            interaction = PrezelChipInteraction.DISABLED,
+            feedback = PrezelChipFeedback.BAD,
+        ),
+        containerColor = PrezelTheme.colors.feedbackWarningSmall,
+        contentColor = PrezelTheme.colors.feedbackWarningRegular,
+    )
+}
+
+@Composable
+private fun CustomRedIconChip() {
+    PrezelChip(
+        text = null,
+        icon = DrawableIcon(resId = PrezelIcons.Blank),
+        style = PrezelChipStyle(
+            type = PrezelChipType.OUTLINED,
+            size = PrezelChipSize.REGULAR,
+            interaction = PrezelChipInteraction.DEFAULT,
+            feedback = PrezelChipFeedback.DEFAULT,
+        ),
+        containerColor = PrezelTheme.colors.feedbackBadSmall,
+        contentColor = PrezelTheme.colors.feedbackBadRegular,
+    )
+}
+
+@Composable
+private fun CustomGreenIconChip() {
+    PrezelChip(
+        text = null,
+        icon = DrawableIcon(resId = PrezelIcons.Blank),
+        style = PrezelChipStyle(
+            type = PrezelChipType.FILLED,
+            size = PrezelChipSize.SMALL,
+            interaction = PrezelChipInteraction.ACTIVE,
+            feedback = PrezelChipFeedback.DEFAULT,
+        ),
+        containerColor = Color(0xFFDBFFF6),
+        contentColor = Color(0xFF00A37A),
+    )
+}

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelCustomChipPreview.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelCustomChipPreview.kt
@@ -78,8 +78,10 @@ private fun CustomYellowLabelChip() {
             interaction = PrezelChipInteraction.DISABLED,
             feedback = PrezelChipFeedback.BAD,
         ),
-        containerColor = PrezelTheme.colors.feedbackWarningSmall,
-        contentColor = PrezelTheme.colors.feedbackWarningRegular,
+        customColors = PrezelChipColors(
+            containerColor = PrezelTheme.colors.feedbackWarningSmall,
+            contentColor = PrezelTheme.colors.feedbackWarningRegular,
+        ),
     )
 }
 
@@ -94,8 +96,10 @@ private fun CustomRedLabelChip() {
             interaction = PrezelChipInteraction.DEFAULT,
             feedback = PrezelChipFeedback.DEFAULT,
         ),
-        containerColor = PrezelTheme.colors.feedbackBadSmall,
-        contentColor = PrezelTheme.colors.feedbackBadRegular,
+        customColors = PrezelChipColors(
+            containerColor = PrezelTheme.colors.feedbackBadSmall,
+            contentColor = PrezelTheme.colors.feedbackBadRegular,
+        ),
     )
 }
 
@@ -110,8 +114,10 @@ private fun CustomGreenLabelChip() {
             interaction = PrezelChipInteraction.ACTIVE,
             feedback = PrezelChipFeedback.DEFAULT,
         ),
-        containerColor = Color(0xFFDBFFF6),
-        contentColor = Color(0xFF00A37A),
+        customColors = PrezelChipColors(
+            containerColor = Color(0xFFDBFFF6),
+            contentColor = Color(0xFF00A37A),
+        ),
     )
 }
 
@@ -126,8 +132,10 @@ private fun CustomYellowIconChip() {
             interaction = PrezelChipInteraction.DISABLED,
             feedback = PrezelChipFeedback.BAD,
         ),
-        containerColor = PrezelTheme.colors.feedbackWarningSmall,
-        contentColor = PrezelTheme.colors.feedbackWarningRegular,
+        customColors = PrezelChipColors(
+            containerColor = PrezelTheme.colors.feedbackWarningSmall,
+            contentColor = PrezelTheme.colors.feedbackWarningRegular,
+        ),
     )
 }
 
@@ -142,8 +150,10 @@ private fun CustomRedIconChip() {
             interaction = PrezelChipInteraction.DEFAULT,
             feedback = PrezelChipFeedback.DEFAULT,
         ),
-        containerColor = PrezelTheme.colors.feedbackBadSmall,
-        contentColor = PrezelTheme.colors.feedbackBadRegular,
+        customColors = PrezelChipColors(
+            containerColor = PrezelTheme.colors.feedbackBadSmall,
+            contentColor = PrezelTheme.colors.feedbackBadRegular,
+        ),
     )
 }
 
@@ -158,7 +168,9 @@ private fun CustomGreenIconChip() {
             interaction = PrezelChipInteraction.ACTIVE,
             feedback = PrezelChipFeedback.DEFAULT,
         ),
-        containerColor = Color(0xFFDBFFF6),
-        contentColor = Color(0xFF00A37A),
+        customColors = PrezelChipColors(
+            containerColor = Color(0xFFDBFFF6),
+            contentColor = Color(0xFF00A37A),
+        ),
     )
 }

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelCustomChipPreview.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelCustomChipPreview.kt
@@ -23,13 +23,7 @@ private fun PrezelChip_CustomColors_Preview() {
     PrezelTheme {
         PreviewScaffold {
             CustomChipHeader()
-
-            Spacer(modifier = Modifier.height(12.dp))
-
             CustomChipLabelSection()
-
-            Spacer(modifier = Modifier.height(16.dp))
-
             CustomChipIconOnlySection()
         }
     }

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelIconChip.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/chip/PrezelIconChip.kt
@@ -1,0 +1,50 @@
+package com.team.prezel.core.designsystem.component.chip
+
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.team.prezel.core.designsystem.icon.DrawableIcon
+import com.team.prezel.core.designsystem.icon.IconSource
+import com.team.prezel.core.designsystem.icon.PrezelIcons
+import com.team.prezel.core.designsystem.preview.PreviewScaffold
+import com.team.prezel.core.designsystem.preview.ThemePreview
+import com.team.prezel.core.designsystem.theme.PrezelTheme
+
+@Composable
+fun PrezelIconChip(
+    icon: IconSource,
+    modifier: Modifier = Modifier,
+    style: PrezelChipStyle = PrezelChipStyle(),
+) {
+    PrezelChip(
+        modifier = modifier,
+        icon = icon,
+        style = style,
+    )
+}
+
+@ThemePreview
+@Composable
+private fun PrezelIconChipPreview() {
+    PrezelTheme {
+        PreviewScaffold {
+            PrezelChipPreviewByType(
+                type = PrezelChipType.FILLED,
+            ) { style -> PrezelIconChipPreviewItem(style) }
+
+            HorizontalDivider()
+
+            PrezelChipPreviewByType(
+                type = PrezelChipType.OUTLINED,
+            ) { style -> PrezelIconChipPreviewItem(style) }
+        }
+    }
+}
+
+@Composable
+private fun PrezelIconChipPreviewItem(style: PrezelChipStyle) {
+    PrezelIconChip(
+        icon = DrawableIcon(resId = PrezelIcons.Blank),
+        style = style,
+    )
+}


### PR DESCRIPTION
## 📌 작업 내용
PrezelChip 구현

분기처리
- Feedback = BAD일 때 -> 붉은색
- Feedback = DEFAULT일때 -> Interaction으로 DEFAULT, ACTIVE, DISABLED 분기처리

<br>

## 🧩 관련 이슈
- close #27 
<br>

## 📸 스크린샷

- PrezelChip
<img width="434" height="490" alt="스크린샷 2026-01-26 01 44 37" src="https://github.com/user-attachments/assets/827352a0-1bb0-462d-8da2-18508b2cf443" />

- IconChip
<img width="434" height="490" alt="스크린샷 2026-01-26 01 44 45" src="https://github.com/user-attachments/assets/9a4b2ee8-783f-4f72-b323-a0bc4975d319" />

- Custom Chip
<img width="434" height="237" alt="스크린샷 2026-01-26 01 44 51" src="https://github.com/user-attachments/assets/4f595060-d662-49ed-b031-ccad13dab0e7" />



<br>

## 📢 논의하고 싶은 내용
1. 우선, 라이트테마에 맞게 설정했습니다. (피그마에 역시 안맞는 색상들이 좀 있어서,,,)
2. 전반적으로 PrezelButton 코드랑 비슷하게 했기때문에 읽기 쉬울거라 예상합니다. 오버로딩쪽봐주세요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 확장된 Chip 컴포넌트 추가: 타입(채움/외곽), 크기, 상호작용 및 피드백 상태 지원
  * 텍스트·아이콘·아이콘 전용 구성 가능(텍스트/아이콘 최소 하나 요구) 및 전용 레이아웃/간격 처리
  * 컨테이너·콘텐츠 색상 오버라이드(커스텀 색상) 및 스타일 설정 지원
  * 간편 아이콘 전용 컴포넌트(PrezelIconChip) 추가

* **디자인/미리보기**
  * 다양한 변형·크기·상호작용·피드백을 시연하는 다수의 미리보기 화면 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->