### PR TITLE
PrezelButtonAreaScope 버튼 중복 추가 문제

### DIFF
--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/actions/area/PrezelButtonArea.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/actions/area/PrezelButtonArea.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
@@ -41,10 +40,11 @@ fun PrezelButtonArea(
     showBackground: Boolean = false,
     isNested: Boolean = false,
     config: PrezelButtonAreaDefault = PrezelButtonAreaDefaults.getDefault(),
-    content: @Composable ButtonAreaScope.() -> Unit,
+    content: ButtonAreaScope.() -> Unit,
 ) {
-    val scope = remember { DefaultButtonAreaScope() }
-    scope.content()
+    val scope = DefaultButtonAreaScope().apply {
+        this.content()
+    }
 
     val mainButton = requireNotNull(scope.buttons.firstOrNull()) {
         "PrezelButtonArea에는 최소 1개의 버튼이 필요합니다."

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/datepicker/PrezelDatePicker.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/datepicker/PrezelDatePicker.kt
@@ -114,12 +114,14 @@ private fun DatePickerFooter(
     selectedDate: LocalDate?,
     onConfirm: (LocalDate) -> Unit,
 ) {
+    val buttonLabel = stringResource(R.string.core_designsystem_date_picker_confirm_btn)
+
     PrezelButtonArea(
         isVertical = false,
         showBackground = true,
     ) {
         MainButton(
-            label = stringResource(R.string.core_designsystem_date_picker_confirm_btn),
+            label = buttonLabel,
             enabled = selectedDate != null,
             onClick = { selectedDate?.let(onConfirm) },
         )

--- a/Prezel/feature/login/impl/src/main/java/com/team/prezel/feature/login/impl/LoginScreen.kt
+++ b/Prezel/feature/login/impl/src/main/java/com/team/prezel/feature/login/impl/LoginScreen.kt
@@ -24,7 +24,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.team.prezel.core.designsystem.component.actions.button.PrezelButton
+import com.team.prezel.core.designsystem.component.actions.area.PrezelButtonArea
+import com.team.prezel.core.designsystem.icon.PrezelIcons
 import com.team.prezel.core.designsystem.preview.BasicPreview
 import com.team.prezel.core.designsystem.theme.PrezelTheme
 import com.team.prezel.feature.login.api.AUTH_LOGO_SHARED_ELEMENT_KEY
@@ -135,13 +136,14 @@ private fun LoginFooter(
             ),
         ),
     ) {
-        // todo: 카카오 로그인으로 수정 필요
-        PrezelButton(
-            modifier = Modifier.fillMaxWidth(),
-            text = "시작하기",
-            onClick = onLogin,
-            enabled = enabled,
-        )
+        PrezelButtonArea(isNested = true) {
+            MainButton(
+                iconResId = PrezelIcons.Blank,
+                label = "시작하기",
+                enabled = enabled,
+                onClick = onLogin,
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## 📌 작업 내용
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->

• 리컴포지션 시 스코프 객체가 재사용되지 않도록 변경
• 리컴포지션이 발생해도 버튼이 중복 추가되지 않음 -> `스코프가 항상 fresh 상태를 유지`
<br>

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
- close #84 
<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 버튼 영역 컴포넌트의 내부 구조 최적화
  * 로그인 화면 버튼 컴포지션 개선
  * 날짜 선택기의 텍스트 리소스 로딩 성능 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->