### PR TITLE
홈 화면 QA 반영

### DIFF
--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/textfield/PrezelTextArea.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/textfield/PrezelTextArea.kt
@@ -14,13 +14,17 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.team.prezel.core.designsystem.component.textfield.component.PrezelTextFieldLabel
@@ -46,18 +50,28 @@ fun PrezelTextArea(
     keyboardActions: KeyboardActions = KeyboardActions.Default,
 ) {
     var focused by remember { mutableStateOf(false) }
+    var textFieldValue by remember { mutableStateOf(TextFieldValue(text = value, selection = TextRange(value.length))) }
+
+    LaunchedEffect(value) {
+        if (value != textFieldValue.text) {
+            textFieldValue = TextFieldValue(text = value, selection = TextRange(value.length))
+        }
+    }
 
     val style = rememberPrezelTextFieldState(
-        value = value,
+        value = textFieldValue.text,
         enabled = enabled,
         focused = focused,
     ).let { state -> PrezelTextFieldStyle(state = state, status = status) }
 
     PrezelTextArea(
-        value = value,
+        value = textFieldValue,
         onValueChange = { newValue ->
-            val applied = applyPrezelTextInputPolicy(newValue, maxLength)
-            if (applied != value) onValueChange(applied)
+            val applied = applyPrezelTextInputPolicy(currentValue = textFieldValue, newValue = newValue, maxLength = maxLength)
+            if (applied != textFieldValue) {
+                textFieldValue = applied
+                if (applied.text != value) onValueChange(applied.text)
+            }
         },
         placeholder = placeholder,
         style = style,
@@ -75,8 +89,8 @@ fun PrezelTextArea(
 
 @Composable
 private fun PrezelTextArea(
-    value: String,
-    onValueChange: (String) -> Unit,
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
     placeholder: String,
     maxLength: Int,
     style: PrezelTextFieldStyle,
@@ -110,13 +124,13 @@ private fun PrezelTextArea(
             decorationBox = { innerTextField ->
                 PrezelTextAreaDecorationBox(
                     innerTextField = innerTextField,
-                    showPlaceholder = !focused && value.isEmpty(),
+                    showPlaceholder = !focused && value.text.isEmpty(),
                     placeholder = placeholder,
                     state = style,
+                    showCounter = showCount,
                     counter = {
                         if (showCount) {
-                            Spacer(modifier = Modifier.height(PrezelTheme.spacing.V16))
-                            Counter(currentLength = value.length, maxLength = maxLength, state = style)
+                            Counter(currentLength = value.text.length, maxLength = maxLength, state = style)
                         }
                     },
                     modifier = Modifier.heightIn(min = 72.dp),
@@ -154,6 +168,7 @@ private fun PrezelTextAreaDecorationBox(
     counter: @Composable () -> Unit,
     placeholder: String,
     state: PrezelTextFieldStyle,
+    showCounter: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Surface(
@@ -163,20 +178,25 @@ private fun PrezelTextAreaDecorationBox(
         border = state.borderStroke(),
         contentColor = state.textColor(),
     ) {
-        Column(
+        Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(PrezelTheme.spacing.V12),
-            verticalArrangement = Arrangement.SpaceBetween,
         ) {
-            Box {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = if (showCounter) PrezelTheme.spacing.V24 else 0.dp),
+            ) {
                 innerTextField()
                 if (showPlaceholder) {
                     PrezelTextFieldPlaceholder(placeholder = placeholder)
                 }
             }
 
-            counter()
+            Box(modifier = Modifier.align(Alignment.BottomEnd)) {
+                counter()
+            }
         }
     }
 }
@@ -304,7 +324,7 @@ private fun PrezelTextAreaPreviewItem(
     focused: Boolean = false,
 ) {
     PrezelTextArea(
-        value = value,
+        value = TextFieldValue(text = value, selection = TextRange(value.length)),
         onValueChange = {},
         placeholder = "Placeholder",
         label = label,

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/textfield/PrezelTextField.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/textfield/PrezelTextField.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -27,6 +28,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import com.team.prezel.core.designsystem.component.textfield.component.PrezelTextFieldLabel
 import com.team.prezel.core.designsystem.component.textfield.component.PrezelTextFieldPlaceholder
@@ -52,18 +55,28 @@ fun PrezelTextField(
     keyboardActions: KeyboardActions = KeyboardActions.Default,
 ) {
     var focused by remember { mutableStateOf(false) }
+    var textFieldValue by remember { mutableStateOf(TextFieldValue(text = value, selection = TextRange(value.length))) }
+
+    LaunchedEffect(value) {
+        if (value != textFieldValue.text) {
+            textFieldValue = TextFieldValue(text = value, selection = TextRange(value.length))
+        }
+    }
 
     val state = rememberPrezelTextFieldState(
-        value = value,
+        value = textFieldValue.text,
         enabled = enabled,
         focused = focused,
     ).let { state -> PrezelTextFieldStyle(state = state, status = status) }
 
     PrezelTextField(
-        value = value,
+        value = textFieldValue,
         onValueChange = { newValue ->
-            val applied = applyPrezelTextInputPolicy(newValue, maxLength)
-            if (applied != value) onValueChange(applied)
+            val applied = applyPrezelTextInputPolicy(currentValue = textFieldValue, newValue = newValue, maxLength = maxLength)
+            if (applied != textFieldValue) {
+                textFieldValue = applied
+                if (applied.text != value) onValueChange(applied.text)
+            }
         },
         placeholder = placeholder,
         style = state,
@@ -80,8 +93,8 @@ fun PrezelTextField(
 
 @Composable
 private fun PrezelTextField(
-    value: String,
-    onValueChange: (String) -> Unit,
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
     placeholder: String,
     style: PrezelTextFieldStyle,
     focused: Boolean,
@@ -115,7 +128,7 @@ private fun PrezelTextField(
             decorationBox = { innerTextField ->
                 PrezelTextFieldDecorationBox(
                     innerTextField = innerTextField,
-                    showPlaceholder = !focused && value.isEmpty(),
+                    showPlaceholder = !focused && value.text.isEmpty(),
                     placeholder = placeholder,
                     trailingIcon = trailingIcon,
                     state = style,
@@ -296,7 +309,7 @@ private fun PreviewTextFieldItem(
     focused: Boolean = false,
 ) {
     PrezelTextField(
-        value = value,
+        value = TextFieldValue(text = value, selection = TextRange(value.length)),
         onValueChange = {},
         placeholder = "Placeholder",
         label = label,

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/textfield/PrezelTextFieldState.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/textfield/PrezelTextFieldState.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import com.team.prezel.core.designsystem.foundation.color.PrezelColors
 import com.team.prezel.core.designsystem.theme.PrezelTheme
@@ -223,11 +224,11 @@ internal fun rememberPrezelTextFieldState(
     )
 
 internal fun applyPrezelTextInputPolicy(
-    value: String,
+    currentValue: TextFieldValue,
+    newValue: TextFieldValue,
     maxLength: Int,
-): String {
-    require(maxLength >= 0) { "maxLength must be >= 0" }
-    return value
-        .replace("\n", "")
-        .take(maxLength)
+): TextFieldValue {
+    require(maxLength >= 0) { "maxLength는 0 이상이어야 합니다." }
+
+    return if (newValue.text.length > maxLength) currentValue else newValue
 }

--- a/Prezel/feature/feedback/impl/src/main/java/com/team/prezel/feature/feedback/impl/FeedbackScreen.kt
+++ b/Prezel/feature/feedback/impl/src/main/java/com/team/prezel/feature/feedback/impl/FeedbackScreen.kt
@@ -17,11 +17,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -174,6 +176,8 @@ private fun FeedbackContent(
     modifier: Modifier = Modifier,
 ) {
     val focusManager = LocalFocusManager.current
+    val placeholders = stringArrayResource(R.array.feature_feedback_impl_placeholders)
+    val placeholder = remember(placeholders.contentHashCode()) { placeholders.random() }
 
     Column(
         modifier = modifier
@@ -193,7 +197,7 @@ private fun FeedbackContent(
         PrezelTextArea(
             value = content,
             onValueChange = onContentChanged,
-            placeholder = stringResource(R.string.feature_feedback_impl_placeholder),
+            placeholder = placeholder,
             maxLength = 200,
             showCount = true,
         )

--- a/Prezel/feature/feedback/impl/src/main/res/values/strings.xml
+++ b/Prezel/feature/feedback/impl/src/main/res/values/strings.xml
@@ -2,7 +2,11 @@
     <string name="feature_feedback_impl_top_app_bar_title">셀프 피드백</string>
     <string name="feature_feedback_impl_close">닫기</string>
     <string name="feature_feedback_impl_question">\'%1$s\'는 어떠셨나요?</string>
-    <string name="feature_feedback_impl_placeholder">다음 발표에는 어떤 부분을 신경쓰고 싶나요?</string>
+    <string-array name="feature_feedback_impl_placeholders">
+        <item>발표를 마친 지금, 어떤 기분이 드나요?</item>
+        <item>다음 발표에서는 무엇을 조금 더 신경 써보고 싶나요?</item>
+        <item>이번 발표에서 만족스러웠던 부분은 무엇이었나요?</item>
+    </string-array>
     <string name="feature_feedback_impl_save">저장하기</string>
     <string name="feature_feedback_impl_fetch_feedback_failed">셀프 피드백을 불러오지 못했어요.</string>
     <string name="feature_feedback_impl_presentation_forbidden">해당 데이터에 접근할 권한이 없습니다.</string>

--- a/Prezel/feature/home/impl/src/main/java/com/team/prezel/feature/home/impl/main/component/body/PresentationSheet.kt
+++ b/Prezel/feature/home/impl/src/main/java/com/team/prezel/feature/home/impl/main/component/body/PresentationSheet.kt
@@ -30,7 +30,13 @@ internal fun PresentationSheet(
         modifier = modifier,
         contentPadding = PaddingValues(vertical = PrezelTheme.spacing.V32, horizontal = PrezelTheme.spacing.V20),
     ) {
-        HomeBottomSheetTitle(title = stringResource(R.string.feature_home_impl_bottom_sheet_content_title, presentation.practiceCount))
+        HomeBottomSheetTitle(
+            title = if (presentation.practiceCount == 0) {
+                stringResource(R.string.feature_home_impl_empty_sheet_practice_card_title)
+            } else {
+                stringResource(R.string.feature_home_impl_bottom_sheet_content_title, presentation.practiceCount)
+            },
+        )
         PracticeCard(
             dDay = presentation.practiceRecords.endDate,
             items = presentation.practiceRecords.practices,

--- a/Prezel/feature/home/impl/src/main/java/com/team/prezel/feature/home/impl/main/component/title/PracticeActionCard.kt
+++ b/Prezel/feature/home/impl/src/main/java/com/team/prezel/feature/home/impl/main/component/title/PracticeActionCard.kt
@@ -32,29 +32,29 @@ internal fun PracticeActionCard(
     modifier: Modifier = Modifier,
     onClick: () -> Unit,
 ) {
-    PrezelTouchArea(
-        onClick = onClick,
-        shape = PrezelTheme.shapes.V8,
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(shape = PrezelTheme.shapes.V8)
+            .border(
+                width = PrezelTheme.stroke.V1,
+                shape = PrezelTheme.shapes.V8,
+                color = PrezelTheme.colors.borderSmall,
+            ).background(color = PrezelTheme.colors.bgRegular)
+            .padding(horizontal = PrezelTheme.spacing.V16, vertical = PrezelTheme.spacing.V12),
     ) {
-        Column(
-            modifier = modifier
-                .fillMaxWidth()
-                .clip(shape = PrezelTheme.shapes.V8)
-                .border(
-                    width = PrezelTheme.stroke.V1,
-                    shape = PrezelTheme.shapes.V8,
-                    color = PrezelTheme.colors.borderSmall,
-                ).background(color = PrezelTheme.colors.bgRegular)
-                .padding(horizontal = PrezelTheme.spacing.V16, vertical = PrezelTheme.spacing.V12),
+        Text(
+            text = title,
+            color = titleColor,
+            style = PrezelTheme.typography.body2Bold,
+        )
+
+        Spacer(modifier = Modifier.height(PrezelTheme.spacing.V6))
+
+        PrezelTouchArea(
+            onClick = onClick,
+            shape = PrezelTheme.shapes.V4,
         ) {
-            Text(
-                text = title,
-                color = titleColor,
-                style = PrezelTheme.typography.body2Bold,
-            )
-
-            Spacer(modifier = Modifier.height(PrezelTheme.spacing.V6))
-
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     text = actionText,


### PR DESCRIPTION
## 📌 작업 내용
홈 화면
- 연습녹음 0회시 "지금부터 연습해보세요" 텍스트 노출
- "발표 분석하기" 텍스트와 ">" 아이콘 Row만 터치되도록 수정

셀프 피드백 작성화면
- 입력값이 없을 때 힌트메세지가 3개 중 랜덤 노출되도록 변경
- 8줄 넘어갈때 200자 counting텍스트 잘림 현상 수정
- 200자 내에서 마지막 줄 말고 다른 줄로 이동해 작성하면 마지막 줄 텍스트가 지워지는 방식으로 계속 입력 가능 > 수정
<br>

## 🧩 관련 이슈
- closes #150 
<br>

## 📸 스크린샷
- 연습녹음 0회시 "지금부터 연습해보세요" 텍스트 노출
<img width="300" alt="Screenshot_1782893539" src="https://github.com/user-attachments/assets/46bbedb1-ab5d-41e6-95f7-408949a07226" />


- 셀프 피드백 화면 200자 카운팅텍스트 잘림현상 수정 
<table>
  <tr>
    <td align="center">
      <b>셀프 피드백 화면 변경 전</b><br />
    </td>
    <td align="center">
      <b>셀프 피드백 화면 변경 후</b><br />
    </td>
  </tr>
  <tr>
    <td align="center">
      <img width="300" alt="셀프 피드백 화면 변경 전" src="https://github.com/user-attachments/assets/daee8d6f-3ea6-4be1-b3ee-662b4f90116a" />
    </td>
    <td align="center">
      <img width="300" alt="셀프 피드백 화면 변경 후" src="https://github.com/user-attachments/assets/e5a934b9-0cd7-457d-bb89-76be48afd9a4" />
    </td>
  </tr>
</table>


<br>

## 📢 논의하고 싶은 내용
- 홈 화면 선택한 탭에 맞게 참고자료가 표시되어야하는 것은 참고자료 api완료 후 추가예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 텍스트 입력창이 커서/선택 상태를 더 자연스럽게 유지하도록 개선됐습니다.
  * 피드백 입력 화면의 안내 문구가 세션마다 다양하게 표시됩니다.
  * 홈 화면의 일부 카드 문구가 상황에 맞게 달라집니다.

* **Bug Fixes**
  * 입력 제한이 초과되면 일부만 잘리는 대신, 이전 입력값을 유지하도록 바뀌었습니다.
  * 텍스트 입력창의 안내 문구와 글자 수 표시가 현재 입력값 기준으로 더 정확하게 동작합니다.
  * 카드 터치 범위가 더 직관적으로 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->