### PR TITLE
홈 화면 2차 QA 반영

### DIFF
--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/PrezelNavigationBar.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/PrezelNavigationBar.kt
@@ -5,18 +5,21 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -28,14 +31,12 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.team.prezel.core.designsystem.component.feedback.snackbar.PrezelSnackbarHost
 import com.team.prezel.core.designsystem.icon.PrezelIcons
 import com.team.prezel.core.designsystem.preview.BasicPreview
 import com.team.prezel.core.designsystem.theme.PrezelTheme
-import com.team.prezel.core.designsystem.util.NoRippleInteractionSource
 
 @Composable
 fun PrezelNavigationBar(
@@ -50,9 +51,12 @@ fun PrezelNavigationBar(
                 .background(PrezelTheme.colors.borderRegular),
         )
 
-        NavigationBar(
-            containerColor = PrezelTheme.colors.bgRegular,
-            tonalElevation = 0.dp,
+        Row(
+            modifier = Modifier
+                .background(PrezelTheme.colors.bgRegular)
+                .padding(horizontal = PrezelTheme.spacing.V20)
+                .navigationBarsPadding(),
+            verticalAlignment = Alignment.CenterVertically,
             content = content,
         )
     }
@@ -66,35 +70,33 @@ fun RowScope.PrezelNavigationBarItem(
     label: String,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    alwaysShowLabel: Boolean = true,
 ) {
-    NavigationBarItem(
-        selected = selected,
-        onClick = onClick,
-        icon = {
-            Icon(
-                painter = painterResource(id = iconResId),
-                contentDescription = null,
-            )
-        },
-        modifier = modifier,
-        enabled = enabled,
-        label = {
-            Text(
-                text = label,
-                style = PrezelTheme.typography.caption2Medium,
-            )
-        },
-        alwaysShowLabel = alwaysShowLabel,
-        colors = NavigationBarItemDefaults.colors(
-            selectedIconColor = PrezelTheme.colors.iconMedium,
-            unselectedIconColor = PrezelTheme.colors.iconDisabled,
-            selectedTextColor = PrezelTheme.colors.textLarge,
-            unselectedTextColor = PrezelTheme.colors.textDisabled,
-            indicatorColor = Color.Transparent,
-        ),
-        interactionSource = NoRippleInteractionSource,
-    )
+    Column(
+        modifier = modifier
+            .weight(1f)
+            .clickable(
+                enabled = enabled,
+                onClick = onClick,
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+            ),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Spacer(modifier = Modifier.height(PrezelTheme.spacing.V12))
+        Icon(
+            modifier = Modifier.size(28.dp),
+            painter = painterResource(id = iconResId),
+            tint = if (selected) PrezelTheme.colors.iconMedium else PrezelTheme.colors.iconDisabled,
+            contentDescription = null,
+        )
+        Spacer(modifier = Modifier.height(PrezelTheme.spacing.V4))
+        Text(
+            text = label,
+            style = PrezelTheme.typography.caption2Medium,
+            color = if (selected) PrezelTheme.colors.textLarge else PrezelTheme.colors.textDisabled,
+        )
+        Spacer(modifier = Modifier.height(PrezelTheme.spacing.V12))
+    }
 }
 
 @Composable
@@ -141,7 +143,6 @@ class PrezelNavigationScope internal constructor(
         onClick: () -> Unit,
         modifier: Modifier = Modifier,
         enabled: Boolean = true,
-        alwaysShowLabel: Boolean = true,
     ) {
         rowScope.PrezelNavigationBarItem(
             selected = selected,
@@ -150,7 +151,6 @@ class PrezelNavigationScope internal constructor(
             label = label,
             modifier = modifier,
             enabled = enabled,
-            alwaysShowLabel = alwaysShowLabel,
         )
     }
 }

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/TopAppBar.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/TopAppBar.kt
@@ -1,67 +1,209 @@
 package com.team.prezel.core.designsystem.component
 
-import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.WindowInsets
+import androidx.annotation.DrawableRes
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.LayoutScopeMarker
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.team.prezel.core.designsystem.component.actions.button.PrezelButton
+import com.team.prezel.core.designsystem.component.actions.button.config.ButtonHierarchy
+import com.team.prezel.core.designsystem.component.actions.button.config.ButtonSize
+import com.team.prezel.core.designsystem.component.actions.button.config.ButtonType
 import com.team.prezel.core.designsystem.icon.PrezelIcons
 import com.team.prezel.core.designsystem.preview.BasicPreview
 import com.team.prezel.core.designsystem.preview.PreviewSection
 import com.team.prezel.core.designsystem.theme.PrezelTheme
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun PrezelTopAppBar(
-    modifier: Modifier = Modifier,
-    title: @Composable () -> Unit = {},
-    leadingIcon: @Composable () -> Unit = {},
-    trailingIcons: @Composable RowScope.() -> Unit = {},
-    scrollBehavior: TopAppBarScrollBehavior? = null,
-    windowInsets: WindowInsets = WindowInsets(),
-) {
-    TopAppBar(
-        title = {
-            ProvideTextStyle(PrezelTheme.typography.body2Bold) {
-                title()
-            }
-        },
-        navigationIcon = leadingIcon,
-        actions = trailingIcons,
-        colors = prezelTopAppBarColors(),
-        scrollBehavior = scrollBehavior,
-        windowInsets = windowInsets,
-        modifier = modifier.testTag("PrezelTopAppBar"),
-    )
+private val TopAppBarHeight = 56.dp
+
+@LayoutScopeMarker
+class PrezelTopAppBarScope {
+    internal var leadingIcon: TopAppBarIcon? = null
+    internal val trailingContents = mutableListOf<TopAppBarTrailingContent>()
+
+    @Composable
+    fun LeadingIcon(
+        @DrawableRes iconResId: Int,
+        contentDescription: String?,
+        onClick: () -> Unit,
+    ) {
+        leadingIcon = TopAppBarIcon(
+            iconResId = iconResId,
+            contentDescription = contentDescription,
+            onClick = onClick,
+        )
+    }
+
+    @Composable
+    fun TrailingIcon(
+        @DrawableRes iconResId: Int,
+        contentDescription: String?,
+        onClick: () -> Unit,
+    ) {
+        trailingContents += TopAppBarTrailingContent.Icon(
+            iconResId = iconResId,
+            contentDescription = contentDescription,
+            onClick = onClick,
+        )
+    }
+
+    @Composable
+    fun TrailingButton(
+        label: String,
+        onClick: () -> Unit,
+    ) {
+        trailingContents += TopAppBarTrailingContent.Button(
+            label = label,
+            onClick = onClick,
+        )
+    }
+}
+
+@Immutable
+internal data class TopAppBarIcon(
+    @param:DrawableRes val iconResId: Int,
+    val contentDescription: String?,
+    val onClick: () -> Unit,
+)
+
+@Immutable
+internal sealed interface TopAppBarTrailingContent {
+    data class Icon(
+        @param:DrawableRes val iconResId: Int,
+        val contentDescription: String?,
+        val onClick: () -> Unit,
+    ) : TopAppBarTrailingContent
+
+    data class Button(
+        val label: String,
+        val onClick: () -> Unit,
+    ) : TopAppBarTrailingContent
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun prezelTopAppBarColors() =
-    TopAppBarDefaults.topAppBarColors(
-        containerColor = Color.Transparent,
-        scrolledContainerColor = PrezelTheme.colors.bgRegular,
-        navigationIconContentColor = PrezelTheme.colors.iconRegular,
-        titleContentColor = PrezelTheme.colors.textLarge,
-        actionIconContentColor = PrezelTheme.colors.iconRegular,
+fun PrezelTopAppBar(
+    title: String?,
+    modifier: Modifier = Modifier,
+    scrollBehavior: TopAppBarScrollBehavior? = null,
+    content: @Composable PrezelTopAppBarScope.() -> Unit = {},
+) {
+    val scope = PrezelTopAppBarScope().apply { content() }
+    val containerColor =
+        animateColorAsState(
+            targetValue = if (scrollBehavior?.state?.overlappedFraction?.let { it > 0f } == true) {
+                PrezelTheme.colors.bgRegular
+            } else {
+                Color.Transparent
+            },
+            animationSpec = tween(),
+            label = "PrezelTopAppBarContainerColor",
+        )
+
+    CompositionLocalProvider(LocalContentColor provides PrezelTheme.colors.iconRegular) {
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .height(TopAppBarHeight)
+                .background(color = containerColor.value),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            scope.leadingIcon?.let { icon ->
+                Spacer(modifier = Modifier.width(PrezelTheme.spacing.V8))
+                PrezelTopAppBarLeadingIcon(icon = icon)
+                Spacer(modifier = Modifier.width(PrezelTheme.spacing.V4))
+            }
+
+            if (scope.leadingIcon == null) Spacer(modifier = Modifier.width(PrezelTheme.spacing.V20))
+            Text(
+                text = title.orEmpty(),
+                style = PrezelTheme.typography.body2Bold,
+                color = PrezelTheme.colors.textLarge,
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(modifier = Modifier.width(PrezelTheme.spacing.V4))
+
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                scope.trailingContents.forEach { trailingContent ->
+                    when (trailingContent) {
+                        is TopAppBarTrailingContent.Button -> PrezelTopAppBarTrailingButton(trailingContent = trailingContent)
+                        is TopAppBarTrailingContent.Icon -> PrezelTopAppBarTrailingIcon(trailingContent = trailingContent)
+                    }
+                }
+            }
+            Spacer(modifier = Modifier.width(PrezelTheme.spacing.V8))
+        }
+    }
+}
+
+@Composable
+private fun PrezelTopAppBarLeadingIcon(icon: TopAppBarIcon) {
+    IconButton(
+        onClick = icon.onClick,
+        shape = PrezelTheme.shapes.V8,
+        modifier = Modifier.size(48.dp),
+    ) {
+        Icon(
+            painter = painterResource(icon.iconResId),
+            contentDescription = icon.contentDescription,
+            modifier = Modifier.size(24.dp),
+        )
+    }
+}
+
+@Composable
+private fun PrezelTopAppBarTrailingIcon(trailingContent: TopAppBarTrailingContent.Icon) {
+    IconButton(
+        onClick = trailingContent.onClick,
+        shape = PrezelTheme.shapes.V8,
+        modifier = Modifier.size(48.dp),
+    ) {
+        Icon(
+            painter = painterResource(trailingContent.iconResId),
+            contentDescription = trailingContent.contentDescription,
+            modifier = Modifier.size(24.dp),
+        )
+    }
+}
+
+@Composable
+private fun PrezelTopAppBarTrailingButton(trailingContent: TopAppBarTrailingContent.Button) {
+    PrezelButton(
+        text = trailingContent.label,
+        type = ButtonType.GHOST,
+        hierarchy = ButtonHierarchy.SECONDARY,
+        size = ButtonSize.SMALL,
+        isRounded = false,
+        onClick = trailingContent.onClick,
     )
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @BasicPreview
 @Composable
 private fun PrezelTopAppBarTitleOnlyPreview() {
     PreviewSection(title = "Title Only") {
-        PrezelTopAppBar(title = { Text(text = "제목") })
+        PrezelTopAppBar(title = "제목")
     }
 }
 
@@ -71,16 +213,14 @@ private fun PrezelTopAppBarTitleOnlyPreview() {
 private fun PrezelTopAppBarWithLeadingPreview() {
     PreviewSection(title = "With Leading") {
         PrezelTopAppBar(
-            title = { Text(text = "제목") },
-            leadingIcon = {
-                IconButton(onClick = {}) {
-                    Icon(
-                        painter = painterResource(PrezelIcons.Blank),
-                        contentDescription = "뒤로가기",
-                    )
-                }
-            },
-        )
+            title = "제목",
+        ) {
+            LeadingIcon(
+                iconResId = PrezelIcons.Blank,
+                contentDescription = "뒤로가기",
+                onClick = {},
+            )
+        }
     }
 }
 
@@ -90,29 +230,22 @@ private fun PrezelTopAppBarWithLeadingPreview() {
 private fun PrezelTopAppBarWithAllIconsPreview() {
     PreviewSection(title = "With All Icons") {
         PrezelTopAppBar(
-            title = { Text(text = "Title") },
-            leadingIcon = {
-                IconButton(onClick = {}) {
-                    Icon(
-                        painter = painterResource(PrezelIcons.Blank),
-                        contentDescription = "뒤로가기",
-                    )
-                }
-            },
-            trailingIcons = {
-                IconButton(onClick = {}) {
-                    Icon(
-                        painter = painterResource(PrezelIcons.Blank),
-                        contentDescription = "검색",
-                    )
-                }
-                IconButton(onClick = {}) {
-                    Icon(
-                        painter = painterResource(PrezelIcons.Blank),
-                        contentDescription = "메뉴",
-                    )
-                }
-            },
-        )
+            title = "Title",
+        ) {
+            LeadingIcon(
+                iconResId = PrezelIcons.Blank,
+                contentDescription = "뒤로가기",
+                onClick = {},
+            )
+            TrailingIcon(
+                iconResId = PrezelIcons.Blank,
+                contentDescription = "검색",
+                onClick = {},
+            )
+            TrailingButton(
+                label = "Label",
+                onClick = {},
+            )
+        }
     }
 }

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/actions/button/floating/menu/PrezelMenu.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/actions/button/floating/menu/PrezelMenu.kt
@@ -2,7 +2,9 @@ package com.team.prezel.core.designsystem.component.actions.button.floating.menu
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -28,6 +30,7 @@ fun PrezelMenu(
 
     Column(
         modifier = modifier
+            .width(IntrinsicSize.Max)
             .clip(shape = config.shape)
             .background(color = config.backgroundColor)
             .padding(config.contentPadding),

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/actions/button/floating/menu/PrezelMenuItem.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/actions/button/floating/menu/PrezelMenuItem.kt
@@ -3,6 +3,8 @@ package com.team.prezel.core.designsystem.component.actions.button.floating.menu
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
@@ -16,7 +18,6 @@ import com.team.prezel.core.designsystem.icon.PrezelIcons
 import com.team.prezel.core.designsystem.preview.BasicPreview
 import com.team.prezel.core.designsystem.preview.PreviewSection
 import com.team.prezel.core.designsystem.preview.PreviewValueRow
-import com.team.prezel.core.designsystem.util.drawDashBorder
 
 /**
  * 메뉴 scope가 실제로 그리는 클릭 가능한 단일 메뉴 아이템입니다.
@@ -31,7 +32,7 @@ internal fun PrezelMenuItem(
     onClick: () -> Unit,
 ) {
     PrezelTouchArea(
-        modifier = modifier,
+        modifier = modifier.fillMaxWidth(),
         onClick = onClick,
         shape = config.shape,
         extraTouchPadding = config.contentPadding,
@@ -52,7 +53,9 @@ private fun PrezelMenuItemLayout(
     modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = modifier,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(config.height),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(
@@ -81,14 +84,14 @@ private fun PrezelMenuMenuItemPreview() {
     ) {
         MenuSize.entries.forEach { size ->
             PreviewValueRow(name = size.name) {
-                PrezelMenu(
-                    size = size,
-                    modifier = Modifier.drawDashBorder(
-                        shape = PrezelMenuDefaults.getDefault(size = size).shape,
-                    ),
-                ) {
+                PrezelMenu(size = size) {
                     MenuItem(
-                        label = "Label",
+                        label = if (size == MenuSize.REGULAR) "Longer Label" else "Label",
+                        iconResId = PrezelIcons.Blank,
+                        onClick = {},
+                    )
+                    MenuItem(
+                        label = "Short",
                         iconResId = PrezelIcons.Blank,
                         onClick = {},
                     )

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/actions/button/floating/menu/PrezelMenuItemDefaults.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/actions/button/floating/menu/PrezelMenuItemDefaults.kt
@@ -29,6 +29,7 @@ data class PrezelMenuItemDefault(
     val textStyle: TextStyle,
     val contentColor: Color,
     val shape: RoundedCornerShape,
+    val height: Dp,
 )
 
 /**
@@ -45,6 +46,7 @@ object PrezelMenuItemDefaults {
             textStyle = getTextStyle(size),
             contentColor = getContentColor(),
             shape = getShape(),
+            height = getHeight(size),
         )
 
     private fun getIconSize(size: MenuItemSize): Dp =
@@ -55,10 +57,11 @@ object PrezelMenuItemDefaults {
 
     @Composable
     private fun getContentPadding(size: MenuItemSize): PaddingValues {
-        val verticalPadding = when (size) {
-            MenuItemSize.SMALL -> PrezelTheme.spacing.V4
-            MenuItemSize.REGULAR -> PrezelTheme.spacing.V8
-        }
+        // 피그마 상으로 아이콘 사이즈를 고려하지 않은 패딩값이 존재하여 높이를 고정으로 하고 가운데 배치하도록 함
+//        val verticalPadding = when (size) {
+//            MenuItemSize.SMALL -> PrezelTheme.spacing.V4
+//            MenuItemSize.REGULAR -> PrezelTheme.spacing.V8
+//        }
 
         val startPadding = when (size) {
             MenuItemSize.SMALL -> PrezelTheme.spacing.V8
@@ -73,8 +76,8 @@ object PrezelMenuItemDefaults {
         return PaddingValues(
             start = startPadding,
             end = endPadding,
-            top = verticalPadding,
-            bottom = verticalPadding,
+//            top = verticalPadding,
+//            bottom = verticalPadding,
         )
     }
 
@@ -96,5 +99,12 @@ object PrezelMenuItemDefaults {
     private fun getContentColor(): Color = PrezelTheme.colors.textMedium
 
     @Composable
-    private fun getShape(): RoundedCornerShape = PrezelTheme.shapes.V8
+    private fun getShape(): RoundedCornerShape = PrezelTheme.shapes.V4
+
+    @Composable
+    private fun getHeight(size: MenuItemSize): Dp =
+        when (size) {
+            MenuItemSize.SMALL -> 28.dp
+            MenuItemSize.REGULAR -> 40.dp
+        }
 }

--- a/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/datepicker/PrezelDatePicker.kt
+++ b/Prezel/core/designsystem/src/main/java/com/team/prezel/core/designsystem/component/datepicker/PrezelDatePicker.kt
@@ -13,8 +13,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -23,7 +21,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -103,16 +100,14 @@ private fun DatePickerHeader(
 ) {
     Column {
         PrezelTopAppBar(
-            title = { Text(text = title) },
-            trailingIcons = {
-                IconButton(onClick = onClose) {
-                    Icon(
-                        painter = painterResource(PrezelIcons.Cancel),
-                        contentDescription = stringResource(R.string.core_designsystem_close_date_picker_desc),
-                    )
-                }
-            },
-        )
+            title = title,
+        ) {
+            TrailingIcon(
+                iconResId = PrezelIcons.Cancel,
+                contentDescription = stringResource(R.string.core_designsystem_close_date_picker_desc),
+                onClick = onClose,
+            )
+        }
         WeekdayRow()
         PrezelHorizontalDivider(type = PrezelDividerType.THICK)
     }

--- a/Prezel/feature/analysis/impl/src/main/java/com/team/prezel/feature/analysis/impl/component/AnalysisStepLayout.kt
+++ b/Prezel/feature/analysis/impl/src/main/java/com/team/prezel/feature/analysis/impl/component/AnalysisStepLayout.kt
@@ -5,26 +5,21 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.team.prezel.core.designsystem.component.PrezelTopAppBar
@@ -32,7 +27,6 @@ import com.team.prezel.core.designsystem.component.actions.area.PrezelButtonArea
 import com.team.prezel.core.designsystem.component.actions.button.PrezelButton
 import com.team.prezel.core.designsystem.component.actions.button.config.ButtonHierarchy
 import com.team.prezel.core.designsystem.component.actions.button.config.ButtonType
-import com.team.prezel.core.designsystem.component.base.PrezelTouchArea
 import com.team.prezel.core.designsystem.icon.PrezelIcons
 import com.team.prezel.core.designsystem.theme.PrezelTheme
 import com.team.prezel.feature.analysis.impl.R
@@ -66,33 +60,28 @@ internal fun AnalysisStepLayout(
             .background(PrezelTheme.colors.bgRegular),
     ) {
         PrezelTopAppBar(
-            title = { Text(text = title) },
-            leadingIcon = {
-                if (isHiddenOptions) return@PrezelTopAppBar
-                IconButton(onClick = onBack) {
-                    Icon(
-                        painter = painterResource(PrezelIcons.ArrowLeft),
-                        contentDescription = stringResource(R.string.feature_analysis_impl_back),
+            title = title,
+        ) {
+            if (isHiddenOptions) {
+                TrailingIcon(
+                    iconResId = PrezelIcons.Cancel,
+                    contentDescription = null,
+                    onClick = onBack,
+                )
+            } else {
+                LeadingIcon(
+                    iconResId = PrezelIcons.ArrowLeft,
+                    contentDescription = stringResource(R.string.feature_analysis_impl_back),
+                    onClick = onBack,
+                )
+                if (trailingText != null && onTrailingTextClick != null) {
+                    TrailingButton(
+                        label = trailingText,
+                        onClick = onTrailingTextClick,
                     )
                 }
-            },
-            trailingIcons = {
-                if (isHiddenOptions) {
-                    IconButton(onClick = onBack) {
-                        Icon(
-                            painter = painterResource(PrezelIcons.Cancel),
-                            contentDescription = null,
-                        )
-                    }
-                    return@PrezelTopAppBar
-                }
-                AnalysisStepTrailingText(
-                    text = trailingText,
-                    onClick = onTrailingTextClick,
-                )
-            },
-        )
-
+            }
+        }
         ProgressBar(progress = progress)
 
         AnalysisStepContent(
@@ -110,26 +99,6 @@ internal fun AnalysisStepLayout(
             onSubButtonClick = onSubButtonClick,
         )
     }
-}
-
-@Composable
-private fun AnalysisStepTrailingText(
-    text: String?,
-    onClick: (() -> Unit)?,
-) {
-    if (text == null || onClick == null) return
-
-    PrezelTouchArea(
-        onClick = onClick,
-        extraTouchPadding = PaddingValues(PrezelTheme.spacing.V8),
-    ) {
-        Text(
-            text = text,
-            color = PrezelTheme.colors.textMedium,
-            style = PrezelTheme.typography.body3Medium,
-        )
-    }
-    Spacer(modifier = Modifier.width(PrezelTheme.spacing.V8))
 }
 
 @Composable

--- a/Prezel/feature/badge/impl/src/main/java/com/team/prezel/feature/badge/impl/component/BadgeDetailModal.kt
+++ b/Prezel/feature/badge/impl/src/main/java/com/team/prezel/feature/badge/impl/component/BadgeDetailModal.kt
@@ -10,13 +10,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import com.team.prezel.core.designsystem.component.PrezelTopAppBar
@@ -50,15 +47,14 @@ internal fun BadgeDetailModal(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         PrezelTopAppBar(
-            trailingIcons = {
-                IconButton(onClick = onDismiss) {
-                    Icon(
-                        painter = painterResource(PrezelIcons.Cancel),
-                        contentDescription = stringResource(R.string.feature_badge_impl_close),
-                    )
-                }
-            },
-        )
+            title = "",
+        ) {
+            TrailingIcon(
+                iconResId = PrezelIcons.Cancel,
+                contentDescription = stringResource(R.string.feature_badge_impl_close),
+                onClick = onDismiss,
+            )
+        }
 
         Spacer(modifier = Modifier.weight(72f))
 

--- a/Prezel/feature/badge/impl/src/main/java/com/team/prezel/feature/badge/impl/component/BadgeListContent.kt
+++ b/Prezel/feature/badge/impl/src/main/java/com/team/prezel/feature/badge/impl/component/BadgeListContent.kt
@@ -10,13 +10,9 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.team.prezel.core.designsystem.component.PrezelTopAppBar
 import com.team.prezel.core.designsystem.icon.PrezelIcons
@@ -37,16 +33,14 @@ internal fun BadgeListContent(
 ) {
     Column(modifier = modifier.fillMaxSize()) {
         PrezelTopAppBar(
-            title = { Text(text = stringResource(R.string.feature_badge_impl_title)) },
-            leadingIcon = {
-                IconButton(onClick = onBack) {
-                    Icon(
-                        painter = painterResource(PrezelIcons.ChevronLeft),
-                        contentDescription = stringResource(R.string.feature_badge_impl_back),
-                    )
-                }
-            },
-        )
+            title = stringResource(R.string.feature_badge_impl_title),
+        ) {
+            LeadingIcon(
+                iconResId = PrezelIcons.ChevronLeft,
+                contentDescription = stringResource(R.string.feature_badge_impl_back),
+                onClick = onBack,
+            )
+        }
 
         LazyVerticalGrid(
             columns = GridCells.Fixed(2),

--- a/Prezel/feature/feedback/impl/src/main/java/com/team/prezel/feature/feedback/impl/FeedbackScreen.kt
+++ b/Prezel/feature/feedback/impl/src/main/java/com/team/prezel/feature/feedback/impl/FeedbackScreen.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -22,7 +20,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalResources
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -154,18 +151,15 @@ private fun FeedbackTopAppBar(
     modifier: Modifier = Modifier,
 ) {
     PrezelTopAppBar(
-        title = { Text(text = stringResource(R.string.feature_feedback_impl_top_app_bar_title)) },
-        trailingIcons = {
-            IconButton(onClick = onClickClose) {
-                Icon(
-                    painter = painterResource(PrezelIcons.Cancel),
-                    contentDescription = stringResource(R.string.feature_feedback_impl_close),
-                    tint = PrezelTheme.colors.iconRegular,
-                )
-            }
-        },
+        title = stringResource(R.string.feature_feedback_impl_top_app_bar_title),
         modifier = modifier,
-    )
+    ) {
+        TrailingIcon(
+            iconResId = PrezelIcons.Cancel,
+            contentDescription = stringResource(R.string.feature_feedback_impl_close),
+            onClick = onClickClose,
+        )
+    }
 }
 
 @Composable

--- a/Prezel/feature/history/impl/src/main/java/com/team/prezel/feature/history/impl/HistoryScreen.kt
+++ b/Prezel/feature/history/impl/src/main/java/com/team/prezel/feature/history/impl/HistoryScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -107,7 +106,7 @@ internal fun HistoryScreen(
     ) {
         PrezelTopAppBar(
             modifier = Modifier.background(PrezelTheme.colors.bgRegular),
-            title = { Text(text = stringResource(R.string.feature_history_impl_title)) },
+            title = stringResource(R.string.feature_history_impl_title),
         )
 
         HistoryContent(

--- a/Prezel/feature/home/impl/src/main/java/com/team/prezel/feature/home/impl/main/component/body/PresentationSheet.kt
+++ b/Prezel/feature/home/impl/src/main/java/com/team/prezel/feature/home/impl/main/component/body/PresentationSheet.kt
@@ -123,7 +123,7 @@ private fun UpcomingPresentationSection(
         curation = firstCuration,
     )
     Spacer(modifier = Modifier.height(PrezelTheme.spacing.V16))
-    Column(verticalArrangement = Arrangement.spacedBy(PrezelTheme.spacing.V16)) {
+    Column(verticalArrangement = Arrangement.spacedBy(PrezelTheme.spacing.V12)) {
         presentation.curations.forEach { curation ->
             CurationCard(
                 curation = curation,

--- a/Prezel/feature/home/impl/src/main/java/com/team/prezel/feature/home/impl/main/component/head/HomeHeadSection.kt
+++ b/Prezel/feature/home/impl/src/main/java/com/team/prezel/feature/home/impl/main/component/head/HomeHeadSection.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -39,7 +38,7 @@ internal fun HomeHeadSection(
             .background(PrezelTheme.colors.bgRegular),
     ) {
         PrezelTopAppBar(
-            title = { Text(text = stringResource(R.string.feature_home_impl_title)) },
+            title = stringResource(R.string.feature_home_impl_title),
         )
 
         if (uiState is HomeUiState.MultipleContent) {

--- a/Prezel/feature/home/impl/src/main/java/com/team/prezel/feature/home/impl/main/component/title/EmptyPresentationHero.kt
+++ b/Prezel/feature/home/impl/src/main/java/com/team/prezel/feature/home/impl/main/component/title/EmptyPresentationHero.kt
@@ -2,6 +2,7 @@ package com.team.prezel.feature.home.impl.main.component.title
 
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -25,6 +26,7 @@ internal fun EmptyPresentationHero(
             color = PrezelTheme.colors.textMedium,
             style = PrezelTheme.typography.title1Medium,
         )
+        Spacer(modifier = Modifier.height(PrezelTheme.spacing.V4))
         Text(
             text = stringResource(R.string.feature_home_impl_empty_subtitle),
             color = PrezelTheme.colors.textLarge,

--- a/Prezel/feature/home/impl/src/main/java/com/team/prezel/feature/home/impl/main/component/title/PracticeActionCard.kt
+++ b/Prezel/feature/home/impl/src/main/java/com/team/prezel/feature/home/impl/main/component/title/PracticeActionCard.kt
@@ -32,29 +32,29 @@ internal fun PracticeActionCard(
     modifier: Modifier = Modifier,
     onClick: () -> Unit,
 ) {
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .clip(shape = PrezelTheme.shapes.V8)
-            .border(
-                width = PrezelTheme.stroke.V1,
-                shape = PrezelTheme.shapes.V8,
-                color = PrezelTheme.colors.borderSmall,
-            ).background(color = PrezelTheme.colors.bgRegular)
-            .padding(horizontal = PrezelTheme.spacing.V16, vertical = PrezelTheme.spacing.V12),
+    PrezelTouchArea(
+        onClick = onClick,
+        shape = PrezelTheme.shapes.V8,
     ) {
-        Text(
-            text = title,
-            color = titleColor,
-            style = PrezelTheme.typography.body2Bold,
-        )
-
-        Spacer(modifier = Modifier.height(PrezelTheme.spacing.V6))
-
-        PrezelTouchArea(
-            onClick = onClick,
-            shape = PrezelTheme.shapes.V4,
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .clip(shape = PrezelTheme.shapes.V8)
+                .border(
+                    width = PrezelTheme.stroke.V1,
+                    shape = PrezelTheme.shapes.V8,
+                    color = PrezelTheme.colors.borderSmall,
+                ).background(color = PrezelTheme.colors.bgRegular)
+                .padding(horizontal = PrezelTheme.spacing.V16, vertical = PrezelTheme.spacing.V12),
         ) {
+            Text(
+                text = title,
+                color = titleColor,
+                style = PrezelTheme.typography.body2Bold,
+            )
+
+            Spacer(modifier = Modifier.height(PrezelTheme.spacing.V6))
+
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     text = actionText,

--- a/Prezel/feature/my/impl/src/main/java/com/team/prezel/feature/my/impl/component/MyTopAppBar.kt
+++ b/Prezel/feature/my/impl/src/main/java/com/team/prezel/feature/my/impl/component/MyTopAppBar.kt
@@ -2,12 +2,8 @@ package com.team.prezel.feature.my.impl.component
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.team.prezel.core.designsystem.component.PrezelTopAppBar
 import com.team.prezel.core.designsystem.icon.PrezelIcons
@@ -20,16 +16,14 @@ import com.team.prezel.feature.my.impl.R
 internal fun MyTopAppBar(onClickSetting: () -> Unit) {
     PrezelTopAppBar(
         modifier = Modifier.fillMaxWidth(),
-        title = { Text(text = stringResource(R.string.feature_my_impl_title)) },
-        trailingIcons = {
-            IconButton(onClick = onClickSetting) {
-                Icon(
-                    painter = painterResource(PrezelIcons.Setting),
-                    contentDescription = null,
-                )
-            }
-        },
-    )
+        title = stringResource(R.string.feature_my_impl_title),
+    ) {
+        TrailingIcon(
+            iconResId = PrezelIcons.Setting,
+            contentDescription = null,
+            onClick = onClickSetting,
+        )
+    }
 }
 
 @BasicPreview

--- a/Prezel/feature/practice/impl/src/main/java/com/team/prezel/feature/practice/impl/recording/component/PracticeRecordingTopAppBar.kt
+++ b/Prezel/feature/practice/impl/src/main/java/com/team/prezel/feature/practice/impl/recording/component/PracticeRecordingTopAppBar.kt
@@ -1,11 +1,7 @@
 package com.team.prezel.feature.practice.impl.recording.component
 
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.team.prezel.core.designsystem.component.PrezelTopAppBar
 import com.team.prezel.core.designsystem.icon.PrezelIcons
@@ -17,16 +13,14 @@ import com.team.prezel.feature.practice.impl.R
 @Composable
 internal fun PracticeRecordingTopAppBar(onBack: () -> Unit) {
     PrezelTopAppBar(
-        title = { Text(text = stringResource(R.string.feature_practice_impl_practice_recording_title)) },
-        leadingIcon = {
-            IconButton(onClick = onBack) {
-                Icon(
-                    painter = painterResource(PrezelIcons.ArrowLeft),
-                    contentDescription = stringResource(R.string.feature_practice_impl_practice_recording_back),
-                )
-            }
-        },
-    )
+        title = stringResource(R.string.feature_practice_impl_practice_recording_title),
+    ) {
+        LeadingIcon(
+            iconResId = PrezelIcons.ArrowLeft,
+            contentDescription = stringResource(R.string.feature_practice_impl_practice_recording_back),
+            onClick = onBack,
+        )
+    }
 }
 
 @BasicPreview

--- a/Prezel/feature/profile/impl/src/main/java/com/team/prezel/feature/profile/impl/component/ProfileScreenTopAppBar.kt
+++ b/Prezel/feature/profile/impl/src/main/java/com/team/prezel/feature/profile/impl/component/ProfileScreenTopAppBar.kt
@@ -1,12 +1,8 @@
 package com.team.prezel.feature.profile.impl.component
 
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.team.prezel.core.designsystem.component.PrezelTopAppBar
 import com.team.prezel.core.designsystem.icon.PrezelIcons
@@ -23,29 +19,16 @@ internal fun ProfileScreenTopAppBar(
 ) {
     PrezelTopAppBar(
         modifier = modifier,
-        title = { ProfileTopBarTitle(isCreate = isCreate) },
-        leadingIcon = {
-            IconButton(onClick = onBack) {
-                Icon(
-                    painter = painterResource(PrezelIcons.ArrowLeft),
-                    contentDescription = stringResource(R.string.feature_profile_impl_topbar_leading_icon_content_description),
-                )
-            }
-        },
-    )
-}
-
-@Composable
-private fun ProfileTopBarTitle(
-    isCreate: Boolean,
-    modifier: Modifier = Modifier,
-) {
-    Text(
-        text = stringResource(
+        title = stringResource(
             id = if (isCreate) R.string.feature_profile_impl_topbar_create_title else R.string.feature_profile_impl_topbar_edit_title,
         ),
-        modifier = modifier,
-    )
+    ) {
+        LeadingIcon(
+            iconResId = PrezelIcons.ArrowLeft,
+            contentDescription = stringResource(R.string.feature_profile_impl_topbar_leading_icon_content_description),
+            onClick = onBack,
+        )
+    }
 }
 
 @BasicPreview

--- a/Prezel/feature/report/impl/src/main/java/com/team/prezel/feature/report/impl/accuracydetail/component/AccuracyDetailTopAppBar.kt
+++ b/Prezel/feature/report/impl/src/main/java/com/team/prezel/feature/report/impl/accuracydetail/component/AccuracyDetailTopAppBar.kt
@@ -1,11 +1,7 @@
 package com.team.prezel.feature.report.impl.accuracydetail.component
 
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.team.prezel.core.designsystem.component.PrezelTopAppBar
 import com.team.prezel.core.designsystem.icon.PrezelIcons
@@ -17,22 +13,14 @@ import com.team.prezel.feature.report.impl.R
 @OptIn(ExperimentalMaterial3Api::class)
 internal fun AccuracyDetailTopAppBar(onClose: () -> Unit) {
     PrezelTopAppBar(
-        title = {
-            Text(
-                text = stringResource(R.string.feature_report_impl_section_accuracy),
-                color = PrezelTheme.colors.textLarge,
-            )
-        },
-        trailingIcons = {
-            IconButton(onClick = onClose) {
-                Icon(
-                    painter = painterResource(PrezelIcons.Cancel),
-                    contentDescription = stringResource(R.string.feature_report_impl_close),
-                    tint = PrezelTheme.colors.iconRegular,
-                )
-            }
-        },
-    )
+        title = stringResource(R.string.feature_report_impl_section_accuracy),
+    ) {
+        TrailingIcon(
+            iconResId = PrezelIcons.Cancel,
+            contentDescription = stringResource(R.string.feature_report_impl_close),
+            onClick = onClose,
+        )
+    }
 }
 
 @BasicPreview

--- a/Prezel/feature/report/impl/src/main/java/com/team/prezel/feature/report/impl/report/AnalysisReportScreen.kt
+++ b/Prezel/feature/report/impl/src/main/java/com/team/prezel/feature/report/impl/report/AnalysisReportScreen.kt
@@ -1,14 +1,11 @@
 package com.team.prezel.feature.report.impl.report
 
 import androidx.annotation.StringRes
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalResources
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -170,14 +167,12 @@ private fun AnalysisReportScreenContent(
 
     ReportScreenLayout(
         appBarTitle = uiState.presentationInfo.title,
-        leadingIcon = {
-            IconButton(onClick = onBackClick) {
-                Icon(
-                    painter = painterResource(PrezelIcons.ArrowLeft),
-                    contentDescription = stringResource(R.string.feature_report_impl_back),
-                    tint = PrezelTheme.colors.iconRegular,
-                )
-            }
+        topAppBarContent = {
+            LeadingIcon(
+                iconResId = PrezelIcons.ArrowLeft,
+                contentDescription = stringResource(R.string.feature_report_impl_back),
+                onClick = onBackClick,
+            )
         },
         headerContent = { titleModifier ->
             ReportHeaderContent(

--- a/Prezel/feature/report/impl/src/main/java/com/team/prezel/feature/report/impl/report/component/ReportScreenLayout.kt
+++ b/Prezel/feature/report/impl/src/main/java/com/team/prezel/feature/report/impl/report/component/ReportScreenLayout.kt
@@ -1,21 +1,16 @@
 package com.team.prezel.feature.report.impl.report.component
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -25,9 +20,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.team.prezel.core.designsystem.component.PrezelTopAppBar
+import com.team.prezel.core.designsystem.component.PrezelTopAppBarScope
 import com.team.prezel.core.designsystem.preview.BasicPreview
 import com.team.prezel.core.designsystem.theme.PrezelTheme
 import com.team.prezel.feature.report.impl.report.preview.ReportPreviewUpcomingUiState
@@ -45,8 +40,7 @@ private data class ReportTopBarState(
 internal fun ReportScreenLayout(
     appBarTitle: String,
     modifier: Modifier = Modifier,
-    leadingIcon: @Composable () -> Unit = {},
-    trailingIcons: @Composable RowScope.() -> Unit = {},
+    topAppBarContent: @Composable PrezelTopAppBarScope.() -> Unit = {},
     headerContent: @Composable ColumnScope.(Modifier) -> Unit,
     bodyContent: @Composable ColumnScope.() -> Unit,
 ) {
@@ -58,8 +52,7 @@ internal fun ReportScreenLayout(
             appBarTitle = appBarTitle,
             topBarState = topBarState,
             onAppBarMeasured = updateAppBarHeight,
-            leadingIcon = leadingIcon,
-            trailingIcons = trailingIcons,
+            content = topAppBarContent,
         )
 
         ReportDetailScrollContent(
@@ -97,32 +90,16 @@ private fun ReportDetailTopAppBar(
     appBarTitle: String,
     topBarState: ReportTopBarState,
     onAppBarMeasured: (Float) -> Unit,
-    leadingIcon: @Composable () -> Unit,
-    trailingIcons: @Composable RowScope.() -> Unit,
+    content: @Composable PrezelTopAppBarScope.() -> Unit,
 ) {
     PrezelTopAppBar(
+        title = if (topBarState.isTitleVisible) appBarTitle else null,
         modifier = Modifier
             .background(PrezelTheme.colors.bgRegular)
             .onGloballyPositioned { coordinates ->
                 onAppBarMeasured(coordinates.size.height.toFloat())
             },
-        title = {
-            AnimatedVisibility(
-                visible = topBarState.isTitleVisible,
-                enter = fadeIn(),
-                exit = fadeOut(),
-            ) {
-                Text(
-                    text = appBarTitle,
-                    style = PrezelTheme.typography.body2Bold,
-                    color = PrezelTheme.colors.textLarge,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-        },
-        leadingIcon = leadingIcon,
-        trailingIcons = trailingIcons,
+        content = content,
     )
 }
 

--- a/Prezel/feature/report/impl/src/main/java/com/team/prezel/feature/report/impl/script/component/ScriptAppBar.kt
+++ b/Prezel/feature/report/impl/src/main/java/com/team/prezel/feature/report/impl/script/component/ScriptAppBar.kt
@@ -1,15 +1,10 @@
 package com.team.prezel.feature.report.impl.script.component
 
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.team.prezel.core.designsystem.component.PrezelTopAppBar
-import com.team.prezel.core.designsystem.icon.PrezelIcons
 import com.team.prezel.core.designsystem.preview.BasicPreview
 import com.team.prezel.core.designsystem.theme.PrezelTheme
 import com.team.prezel.feature.report.impl.R
@@ -23,23 +18,14 @@ internal fun ScriptAppBar(
 ) {
     PrezelTopAppBar(
         modifier = modifier,
-        title = {
-            Text(
-                text = title,
-                style = PrezelTheme.typography.body2Bold,
-                color = PrezelTheme.colors.textLarge,
-            )
-        },
-        trailingIcons = {
-            IconButton(onClick = onCloseClick) {
-                Icon(
-                    painter = painterResource(PrezelIcons.Cancel),
-                    contentDescription = stringResource(R.string.feature_report_impl_close),
-                    tint = PrezelTheme.colors.iconRegular,
-                )
-            }
-        },
-    )
+        title = title,
+    ) {
+        TrailingIcon(
+            iconResId = com.team.prezel.core.designsystem.icon.PrezelIcons.Cancel,
+            contentDescription = stringResource(R.string.feature_report_impl_close),
+            onClick = onCloseClick,
+        )
+    }
 }
 
 @BasicPreview

--- a/Prezel/feature/setting/impl/src/main/java/com/team/prezel/feature/setting/impl/delete/component/DeleteAccountTopAppBar.kt
+++ b/Prezel/feature/setting/impl/src/main/java/com/team/prezel/feature/setting/impl/delete/component/DeleteAccountTopAppBar.kt
@@ -1,11 +1,8 @@
 package com.team.prezel.feature.setting.impl.delete.component
 
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.team.prezel.core.designsystem.component.PrezelTopAppBar
 import com.team.prezel.core.designsystem.icon.PrezelIcons
@@ -21,15 +18,14 @@ internal fun DeleteAccountTopAppBar(
 ) {
     PrezelTopAppBar(
         modifier = modifier,
-        trailingIcons = {
-            IconButton(onClick = onClickClose) {
-                Icon(
-                    painter = painterResource(PrezelIcons.Cancel),
-                    contentDescription = stringResource(R.string.feature_setting_impl_close_icon_content_description),
-                )
-            }
-        },
-    )
+        title = "",
+    ) {
+        TrailingIcon(
+            iconResId = PrezelIcons.Cancel,
+            contentDescription = stringResource(R.string.feature_setting_impl_close_icon_content_description),
+            onClick = onClickClose,
+        )
+    }
 }
 
 @BasicPreview

--- a/Prezel/feature/setting/impl/src/main/java/com/team/prezel/feature/setting/impl/setting/component/SettingTopAppBar.kt
+++ b/Prezel/feature/setting/impl/src/main/java/com/team/prezel/feature/setting/impl/setting/component/SettingTopAppBar.kt
@@ -1,12 +1,8 @@
 package com.team.prezel.feature.setting.impl.setting.component
 
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.team.prezel.core.designsystem.component.PrezelTopAppBar
 import com.team.prezel.core.designsystem.icon.PrezelIcons
@@ -22,18 +18,14 @@ internal fun SettingTopAppBar(
 ) {
     PrezelTopAppBar(
         modifier = modifier,
-        title = {
-            Text(text = stringResource(R.string.feature_setting_impl_title))
-        },
-        leadingIcon = {
-            IconButton(onClick = onBack) {
-                Icon(
-                    painter = painterResource(PrezelIcons.ArrowLeft),
-                    contentDescription = stringResource(R.string.feature_setting_impl_back_icon_content_description),
-                )
-            }
-        },
-    )
+        title = stringResource(R.string.feature_setting_impl_title),
+    ) {
+        LeadingIcon(
+            iconResId = PrezelIcons.ArrowLeft,
+            contentDescription = stringResource(R.string.feature_setting_impl_back_icon_content_description),
+            onClick = onBack,
+        )
+    }
 }
 
 @BasicPreview

--- a/Prezel/feature/terms/impl/src/main/java/com/team/prezel/feature/terms/impl/TermsScreen.kt
+++ b/Prezel/feature/terms/impl/src/main/java/com/team/prezel/feature/terms/impl/TermsScreen.kt
@@ -13,8 +13,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -24,7 +22,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalResources
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -145,18 +142,14 @@ private fun TermsScreenTopAppBar(
 ) {
     PrezelTopAppBar(
         modifier = modifier,
-        title = {
-            Text(text = stringResource(R.string.feature_terms_impl_terms_title))
-        },
-        leadingIcon = {
-            IconButton(onClick = onBack) {
-                Icon(
-                    painter = painterResource(PrezelIcons.ArrowLeft),
-                    contentDescription = stringResource(R.string.feature_terms_impl_back_icon_description),
-                )
-            }
-        },
-    )
+        title = stringResource(R.string.feature_terms_impl_terms_title),
+    ) {
+        LeadingIcon(
+            iconResId = PrezelIcons.ArrowLeft,
+            contentDescription = stringResource(R.string.feature_terms_impl_back_icon_description),
+            onClick = onBack,
+        )
+    }
 }
 
 @Composable

--- a/Prezel/feature/terms/impl/src/main/java/com/team/prezel/feature/terms/impl/component/TermsDetailModal.kt
+++ b/Prezel/feature/terms/impl/src/main/java/com/team/prezel/feature/terms/impl/component/TermsDetailModal.kt
@@ -8,14 +8,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.zIndex
@@ -41,16 +38,14 @@ internal fun TermsDetailModal(
             .fillMaxSize(),
     ) {
         PrezelTopAppBar(
-            title = { androidx.compose.material3.Text(text = title) },
-            trailingIcons = {
-                IconButton(onClick = onDismiss) {
-                    Icon(
-                        painter = painterResource(PrezelIcons.Cancel),
-                        contentDescription = stringResource(R.string.feature_terms_impl_cancel_icon_description),
-                    )
-                }
-            },
-        )
+            title = title,
+        ) {
+            TrailingIcon(
+                iconResId = PrezelIcons.Cancel,
+                contentDescription = stringResource(R.string.feature_terms_impl_cancel_icon_description),
+                onClick = onDismiss,
+            )
+        }
         NotionWebView(url = url, modifier = Modifier.weight(1f))
     }
 }


### PR DESCRIPTION
## 📌 작업 내용
<!-- ex. 
- 사용자 로그인 기능 구현
- 로그인 실패 시 에러 메시지 반환 처리 추가 -->
- [x] Empty Content 타이틀 행간 간격 수정
- [x] TopBar DS Component 수정 (재구현 필요)
- [x] 클릭 범위를 카드 전체로 수정
- [x] 카드 상하 마진 수정
- [x] 바텀 네비게이션 구현 검토
- [x] 아티클 사이 간격 수정
- [x] FAB 메뉴 내부 간격 수정
- [x] 아이템 터치 효과 너비 맞추도록 수정
<br>

## 🧩 관련 이슈
<!-- 이슈 태그: #123 -->
<!-- 이슈 닫기: close #123 -->
- close #170 
<br>

## 📸 스크린샷
<!-- UI 변경이 있을 경우 첨부 -->
<br>

## 📢 논의하고 싶은 내용
<!-- 이러이러해서 이부분을 이러이러하게 구현했는데 이방식이 괜찮은지? -->
