### PR TITLE
3차 QA 반영 2 

### DIFF
--- a/Prezel/feature/analysis/impl/src/main/java/com/team/prezel/feature/analysis/impl/component/AnalysisStepLayout.kt
+++ b/Prezel/feature/analysis/impl/src/main/java/com/team/prezel/feature/analysis/impl/component/AnalysisStepLayout.kt
@@ -45,6 +45,7 @@ internal fun AnalysisStepLayout(
     contentScrollable: Boolean = true,
     alwaysShowButtonAreaDivider: Boolean = false,
     isHiddenOptions: Boolean = false,
+    showProgressBar: Boolean = true,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     val contentScrollState = rememberScrollState()
@@ -79,7 +80,9 @@ internal fun AnalysisStepLayout(
                 }
             }
         }
-        ProgressBar(progress = progress)
+        if (showProgressBar) {
+            ProgressBar(progress = progress)
+        }
 
         AnalysisStepContent(
             scrollState = contentScrollState,

--- a/Prezel/feature/analysis/impl/src/main/java/com/team/prezel/feature/analysis/impl/component/AnalysisStepLayout.kt
+++ b/Prezel/feature/analysis/impl/src/main/java/com/team/prezel/feature/analysis/impl/component/AnalysisStepLayout.kt
@@ -26,6 +26,7 @@ import com.team.prezel.core.designsystem.component.actions.button.config.ButtonH
 import com.team.prezel.core.designsystem.component.actions.button.config.ButtonType
 import com.team.prezel.core.designsystem.icon.PrezelIcons
 import com.team.prezel.core.designsystem.theme.PrezelTheme
+import com.team.prezel.core.ui.util.advancedImePadding
 import com.team.prezel.feature.analysis.impl.R
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -128,7 +129,9 @@ private fun AnalysisStepButtonArea(
     onSubButtonClick: (() -> Unit)?,
 ) {
     PrezelButtonArea(
-        modifier = Modifier.background(PrezelTheme.colors.bgRegular),
+        modifier = Modifier
+            .background(PrezelTheme.colors.bgRegular)
+            .advancedImePadding(),
         showBackground = showDivider,
         mainButton = { modifier ->
             PrezelButton(

--- a/Prezel/feature/analysis/impl/src/main/java/com/team/prezel/feature/analysis/impl/script/ScriptInputScreen.kt
+++ b/Prezel/feature/analysis/impl/src/main/java/com/team/prezel/feature/analysis/impl/script/ScriptInputScreen.kt
@@ -158,6 +158,7 @@ private fun ScriptInputScreen(
         onButtonClick = onNext,
         onBack = onBack,
         isHiddenOptions = isHiddenOptions,
+        showProgressBar = !isHiddenOptions,
         trailingText = stringResource(R.string.feature_analysis_impl_skip),
         onTrailingTextClick = onSkip,
         contentScrollable = false,

--- a/Prezel/feature/report/impl/src/main/java/com/team/prezel/feature/report/impl/accuracydetail/AccuracyDetailScreen.kt
+++ b/Prezel/feature/report/impl/src/main/java/com/team/prezel/feature/report/impl/accuracydetail/AccuracyDetailScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
@@ -39,6 +39,7 @@ import com.team.prezel.core.model.presentation.WordAnalysisStatus
 import com.team.prezel.core.ui.state.LocalSnackbarHostState
 import com.team.prezel.feature.report.impl.R
 import com.team.prezel.feature.report.impl.accuracydetail.component.AccuracyDetailPlayerSheet
+import com.team.prezel.feature.report.impl.accuracydetail.component.AccuracyDetailSheetPeekHeight
 import com.team.prezel.feature.report.impl.accuracydetail.component.AccuracyDetailTopAppBar
 import com.team.prezel.feature.report.impl.accuracydetail.component.ScriptDetailList
 import com.team.prezel.feature.report.impl.accuracydetail.component.toMarkerType
@@ -148,7 +149,8 @@ private fun AccuracyDetailScreenContent(
         }
     }
     val scaffoldState = rememberDetailScaffoldState(expandedSheet = expandedSheet)
-    val isSheetExpanded = scaffoldState.isSheetExpanded
+    val isSheetLayoutExpanded = scaffoldState.isSheetLayoutExpanded
+    val showTopBar = !scaffoldState.isSheetTargetExpanded
 
     PlaybackEffect(
         playerState = playerState,
@@ -161,7 +163,8 @@ private fun AccuracyDetailScreenContent(
         selectedSentence = selectedSentence,
         sentenceDetails = sentenceDetails,
         playerState = playerState,
-        expanded = isSheetExpanded,
+        expanded = isSheetLayoutExpanded,
+        showTopBar = showTopBar,
         onClose = onClose,
         tabLabels = tabLabels,
         onClickTab = { index -> pagerState.requestScrollToPage(index) },
@@ -215,9 +218,13 @@ private fun rememberDetailScaffoldState(expandedSheet: Boolean): BottomSheetScaf
     )
 
 @OptIn(ExperimentalMaterial3Api::class)
-private val BottomSheetScaffoldState.isSheetExpanded: Boolean
+private val BottomSheetScaffoldState.isSheetLayoutExpanded: Boolean
     get() = bottomSheetState.currentValue == SheetValue.Expanded ||
         bottomSheetState.targetValue == SheetValue.Expanded
+
+@OptIn(ExperimentalMaterial3Api::class)
+private val BottomSheetScaffoldState.isSheetTargetExpanded: Boolean
+    get() = bottomSheetState.targetValue == SheetValue.Expanded
 
 @Composable
 private fun PlaybackEffect(
@@ -264,6 +271,7 @@ private fun AccuracyDetailScaffold(
     sentenceDetails: ImmutableList<SentenceAnalysisUiModel>,
     playerState: PrezelPlayerState,
     expanded: Boolean,
+    showTopBar: Boolean,
     onClose: () -> Unit,
     tabLabels: ImmutableList<String>,
     onClickTab: (Int) -> Unit,
@@ -275,7 +283,7 @@ private fun AccuracyDetailScaffold(
         BottomSheetScaffold(
             modifier = Modifier.fillMaxSize(),
             scaffoldState = scaffoldState,
-            sheetPeekHeight = 276.dp,
+            sheetPeekHeight = AccuracyDetailSheetPeekHeight,
             sheetShape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
             sheetContainerColor = PrezelTheme.colors.solidWhite,
             sheetShadowElevation = if (expanded) 0.dp else 12.dp,
@@ -286,14 +294,7 @@ private fun AccuracyDetailScaffold(
                     sentenceDetails = sentenceDetails,
                     playerState = playerState,
                     expanded = expanded,
-                    modifier = Modifier
-                        .then(
-                            if (expanded) {
-                                Modifier.heightIn(max = expandedSheetMaxHeight)
-                            } else {
-                                Modifier
-                            },
-                        ),
+                    modifier = Modifier.height(expandedSheetMaxHeight),
                 )
             },
             sheetDragHandle = null,
@@ -304,7 +305,7 @@ private fun AccuracyDetailScaffold(
                     .fillMaxSize()
                     .padding(innerPadding),
             ) {
-                if (!expanded) {
+                if (showTopBar) {
                     AccuracyDetailTopAppBar(onClose = onClose)
                 }
                 PrezelTabs(

--- a/Prezel/feature/report/impl/src/main/java/com/team/prezel/feature/report/impl/accuracydetail/component/AccuracyDetailPlayerSheet.kt
+++ b/Prezel/feature/report/impl/src/main/java/com/team/prezel/feature/report/impl/accuracydetail/component/AccuracyDetailPlayerSheet.kt
@@ -9,8 +9,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -45,6 +43,8 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 
+internal val AccuracyDetailSheetPeekHeight = 276.dp
+
 @Composable
 internal fun AccuracyDetailPlayerSheet(
     selectedTab: AccuracyDetailTab,
@@ -54,28 +54,29 @@ internal fun AccuracyDetailPlayerSheet(
     expanded: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier.then(
-            if (expanded) {
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(
+            modifier = if (expanded) {
                 Modifier.fillMaxSize()
             } else {
-                Modifier.fillMaxWidth()
+                Modifier
+                    .fillMaxWidth()
+                    .height(AccuracyDetailSheetPeekHeight)
             },
-        ),
-    ) {
-        SheetHandle()
-        SheetDetailContent(
-            selectedTab = selectedTab,
-            selectedSentence = selectedSentence,
-            sentenceDetails = sentenceDetails,
-            expanded = expanded,
-            modifier = if (expanded) Modifier.weight(1f) else Modifier,
-        )
-        PrezelPlayer(
-            state = playerState,
-            trackContentDescription = stringResource(R.string.feature_report_impl_script_detail_player_track_desc),
-            modifier = Modifier.navigationBarsPadding(),
-        )
+        ) {
+            SheetHandle()
+            SheetDetailContent(
+                selectedTab = selectedTab,
+                selectedSentence = selectedSentence,
+                sentenceDetails = sentenceDetails,
+                expanded = expanded,
+                modifier = Modifier.weight(1f),
+            )
+            PrezelPlayer(
+                state = playerState,
+                trackContentDescription = stringResource(R.string.feature_report_impl_script_detail_player_track_desc),
+            )
+        }
     }
 }
 
@@ -213,6 +214,7 @@ private fun SpeechDetailContent(
             SentenceAnalysisCard(
                 detail = detail,
                 highlighted = detail == highlightedDetail,
+                text = detail.mainFeedback,
                 subText = detail.subFeedback.takeIf { expanded },
                 useStatusTextColor = false,
                 status = detail.speechAccuracyStatus,
@@ -261,7 +263,6 @@ private fun ScriptMatchDetailContent(
             SentenceAnalysisCard(
                 detail = detail,
                 highlighted = detail == highlightedDetail,
-                modifier = Modifier.heightIn(min = 104.dp),
                 text = detail.mainFeedback,
                 useStatusTextColor = false,
                 status = detail.scriptMatchStatus,


### PR DESCRIPTION
## 📌 작업 내용
- 리포트에서 다시 대본 쓰기로 진입한 경우 진행률 표시를 숨겼습니다.
- 키보드 노출 시 분석 입력 화면의 하단 버튼과 TextArea가 가려지지 않도록 개선했습니다.
- 정확도 상세 BottomSheet의 확장·축소 레이아웃과 player 배치를 안정화했습니다.
<br>

## 🧩 관련 이슈
closes #180 
<br>
